### PR TITLE
feat: 长按 repeat 机制 + Tetris 完整实现 + 暂停 / 消行动画

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,14 @@ concurrency:
 
 permissions:
   contents: read
-  # PR 评论需要写权限：vitest-coverage-report-action 把覆盖率 summary 帖到 PR
-  pull-requests: write
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # 仅本 job 需要 PR 写权限：覆盖率 action 帖评论到 PR
+      pull-requests: write
     timeout-minutes: 10
 
     steps:
@@ -57,7 +59,7 @@ jobs:
       # action 直接读 coverage/coverage-summary.json，无外部服务依赖。
       - name: PR coverage report
         if: github.event_name == 'pull_request'
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2.11.2
         with:
           json-summary-path: coverage/coverage-summary.json
           json-final-path: coverage/coverage-final.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
-# PR opened / 新 commit 到分支时跑基础 CI 检查：lint + test + build。
+# PR opened / 新 commit 到分支时跑基础 CI 检查：lint + test + coverage + build。
 #
 # 设计要点：
 #   - 单 job 串行跑完（项目测试 < 10s，不需要按 shard 并行）
+#   - test 步骤改 coverage：跑测试 + 生成覆盖率，比单独跑省一次启动开销
 #   - pnpm build 内已含 tsc --noEmit（见 package.json），无需单独 typecheck 步骤
 #   - Node 版本锁定 .nvmrc，pnpm 版本锁定 package.json 的 packageManager 字段
 name: ci
@@ -19,6 +20,8 @@ concurrency:
 
 permissions:
   contents: read
+  # PR 评论需要写权限：vitest-coverage-report-action 把覆盖率 summary 帖到 PR
+  pull-requests: write
 
 jobs:
   check:
@@ -44,8 +47,17 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Test
-        run: pnpm test
+      - name: Test + Coverage
+        run: pnpm coverage
 
       - name: Build
         run: pnpm build
+
+      # 把覆盖率 summary 表帖到 PR comment（仅 PR 触发时跑）。
+      # action 直接读 coverage/coverage-summary.json，无外部服务依赖。
+      - name: PR coverage report
+        if: github.event_name == 'pull_request'
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-path: coverage/coverage-summary.json
+          json-final-path: coverage/coverage-final.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,6 @@ pre-commit 钩子会自动对 staged 文件跑 `eslint --fix` + `prettier --writ
   - `type` 取自：`feat` / `fix` / `build` / `chore` / `docs` / `test` / `refactor` / `style` / `perf`
   - 英文冒号 + 半角空格 + 中文描述，标题 ≤ 72 字
   - 需要解释原因时，空行后写 body
-- 一个 commit 只做一件事；**格式化 / 重命名 / 移动**与**逻辑变更**分开提交
 - 不提交 `console.log` / `debugger` / 死代码 / 被注释掉的旧实现
 - AI 助手不得主动 `git push` 或执行 `gh pr create` / `gh pr edit` 等对远端产生可见变更的动作；**推送 / 开 PR / 改远端 PR 只能在用户明确指令后执行**
 - `gh` CLI 已纳入项目工具链；AI 处理 PR 相关操作（提 / 关 / 改 body / 评论）一律走 `gh`，不让用户手动点链接
@@ -47,6 +46,10 @@ pre-commit 钩子会自动对 staged 文件跑 `eslint --fix` + `prettier --writ
   2. 按本文件 + `docs/ARCHITECTURE.md` 做一次中文评审，列高价值问题
   3. 用户修完或确认无问题后，再 `gh pr create`
 - 远程侧由 CodeRabbit 与 Gemini Code Assist（均为 GitHub App）自动复审，配置文件在 `.coderabbit.yaml` / `.gemini/`；AI 本地 CR 与远程 App CR 互为补充
+- **AI 修复 CR 问题后必须收尾**：
+  1. 已修复的 review thread 要 resolve（通过 GraphQL `resolveReviewThread`）
+  2. PR body 中的 test plan checklist 要据实打勾
+  3. PR body 要同步更新以反映后续 commit 的变更（如新增 / 删除的功能点）
 
 ## 四层架构
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build": "tsc --noEmit && vite build",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "test": "vitest run",
+    "coverage": "vitest run --coverage",
     "prepare": "husky"
   },
   "lint-staged": {
@@ -51,6 +52,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "@vitest/ui": "^4.1.5",
     "eslint": "^9.0.0",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.5
+        version: 4.1.5(vitest@4.1.5)
       '@vitest/ui':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -80,7 +83,7 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3))
 
 packages:
 
@@ -172,6 +175,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -639,6 +646,15 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/coverage-v8@4.1.5':
+    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+    peerDependencies:
+      '@vitest/browser': 4.1.5
+      vitest: 4.1.5
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -723,6 +739,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1012,6 +1031,9 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -1057,6 +1079,21 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1207,6 +1244,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -1788,6 +1832,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -2202,6 +2248,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3)
 
+  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.5
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.1.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3))
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2246,7 +2306,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3))
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -2292,6 +2352,12 @@ snapshots:
   aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   balanced-match@1.0.2: {}
 
@@ -2558,6 +2624,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-escaper@2.0.2: {}
+
   husky@9.1.7: {}
 
   ignore@5.3.2: {}
@@ -2588,6 +2656,21 @@ snapshots:
   is-potential-custom-element-name@1.0.1: {}
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2732,6 +2815,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   mdn-data@2.27.1: {}
 
@@ -3024,7 +3117,7 @@ snapshots:
       sass: 1.99.0
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@25.6.0)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(sass@1.99.0)(yaml@2.8.3))
@@ -3048,6 +3141,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
       '@vitest/ui': 4.1.5(vitest@4.1.5)
       jsdom: 29.0.2
     transitivePeerDependencies:

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -44,22 +44,13 @@ import {
 const BOOT_TICK_SPEED = 60;
 
 /**
- * 加速键集合：按住任一键 → ticker 速度 × BOOST_FACTOR。Rotate / 同向 / 异向
- * 方向键都算进来，按下时长按持续生效；松开后若集合空则取消加速。
+ * 游戏内动画速度：每秒 30 帧。
  *
- * 选 ticker 提频而不是 step 内一帧两步：保持每帧推进一格的视觉流畅感（用户
- * 反馈"一帧两格"看起来在跳跃），同时切方向时只要新键还按着就不掉 boost
+ * 在 game 进入"动画态"（Snake 死亡爆炸 / Tetris 消行闪烁等）时，App 把 ticker
+ * 切到这个固定值。这样动画节奏不被玩家选的 baseline tickSpeed 拖慢——speed=1
+ * 的慢节奏游戏也能用 ~33ms/帧 干脆的速度播完动画
  */
-const BOOST_KEYS: ReadonlySet<Button> = new Set(['Up', 'Down', 'Left', 'Right', 'A']);
-const BOOST_FACTOR = 3;
-
-/**
- * Game Over 死亡动画速度：每秒 30 帧。
- *
- * 当前接入的是 Snake 的两阶段动画（爆炸 30 帧 + 填屏 20 帧 ≈ 1.7s），
- * 每帧推进 1 个 overFrame。继续上调到 40+ 会显得仓促。
- */
-const GAME_OVER_ANIM_SPEED = 30;
+const ANIM_TICK_SPEED = 30;
 
 /**
  * 应用 mode 状态机：
@@ -201,10 +192,22 @@ function reduce(state: AppState, action: Action, deps: ReduceDeps): AppState {
     return state;
   }
 
-  // playing：game.onButton 接管按键。原本游戏结束时按 Start 重开局的分支已不
-  // 可达（input 层把 Start 拦截作 POWER_OFF），重开由 Snake step 死亡动画
-  // 自动 init + Reset 回 select 两条路径覆盖
+  // playing：Reset 重开当前局；Select 退回菜单；其它走 game.onButton。
+  // 原本游戏结束时按 Start 重开局的分支已不可达（input 层把 Start 拦截
+  // 作 POWER_OFF）。Reset 在 playing 重开 / select 时退回菜单
   if (state.playingId) {
+    if (kind === 'press' && button === 'Reset') {
+      const game = registry.get(state.playingId);
+      if (isPlayable(game)) {
+        return {
+          ...state,
+          gameState: game.init(env, { speed: state.menu.speed, level: state.menu.level }),
+        };
+      }
+    }
+    if (kind === 'press' && button === 'Select') {
+      return { ...state, mode: 'select', playingId: null, gameState: null };
+    }
     const game = registry.get(state.playingId);
     if (game?.onButton) {
       const next = game.onButton(env, state.gameState, button, kind);
@@ -214,9 +217,6 @@ function reduce(state: AppState, action: Action, deps: ReduceDeps): AppState {
     }
   }
 
-  if (kind === 'press' && (button === 'Select' || button === 'Reset')) {
-    return { ...state, mode: 'select', playingId: null, gameState: null };
-  }
   return state;
 }
 
@@ -258,12 +258,6 @@ export function App(): React.ReactElement {
     modeRef.current = state.mode;
   }, [state.mode]);
 
-  // 加速：当前按住的 boost 键集合 + 派生 boost 状态。Ref 跟踪集合，state 触发
-  // ticker 速度 useEffect 重算。多键场景靠集合天然处理：按 Right + 按 Up，
-  // 松开 Right 后 Up 仍按着 → 集合非空 → 仍 boost
-  const pressedBoostRef = useRef<Set<Button>>(new Set());
-  const [boost, setBoost] = useState(false);
-
   // 通电：把"启动旋律"和"切 mode 到 boot"封装成单一动作，让 ON/OFF 按键
   // 触发和 mount 时探测 autoplay 自动触发走同一通路。playMelody 必须在
   // user gesture 同步调用栈内才能被浏览器允许 resume AudioContext
@@ -276,44 +270,70 @@ export function App(): React.ReactElement {
   useEffect(() => {
     const unbind = bindKeyboardInput(ctx.input);
     const unsub = ctx.input.subscribe((button, kind) => {
-      // 关机状态：仅 ON/OFF（emit='Start'）通电，其它按键全部无响应，
-      // 模拟真机"没插电"的表现
-      if (modeRef.current === 'off') {
-        if (kind === 'press' && button === 'Start') powerOn();
-        return;
+      // 控制键（Start / Pause / Sound / Reset）只响 press，repeat / release 无效。
+      // 长按这些键没有"持续"语义；处理完直接 return，不进 reducer
+      if (kind === 'press') {
+        switch (button) {
+          case 'Start':
+            if (modeRef.current === 'off') {
+              powerOn();
+            } else {
+              // 关机：取消旋律 + 重置 pause + state 整体清零
+              melodyCancelRef.current?.();
+              melodyCancelRef.current = null;
+              ctx.pause.set(false);
+              dispatch({ type: 'POWER_OFF' });
+            }
+            return;
+          case 'Pause':
+            // 仅 playing 模式切换暂停，其它模式 no-op 不响 click
+            if (modeRef.current === 'playing') {
+              ctx.pause.toggle();
+              ctx.sound.play('move');
+            }
+            return;
+          case 'Sound':
+            // 先 toggle 后 play：切到 ON 那一下听到 click；切到 OFF 时已静音听不见
+            ctx.soundOn.toggle();
+            ctx.sound.play('move');
+            return;
+          case 'Reset':
+            // Reset 顺带清暂停；reducer 在 playing 模式重开当前局，Reset 自身不响 click
+            if (ctx.pause.value) ctx.pause.set(false);
+            break;
+        }
       }
-      // 已开机时按 ON/OFF = 关机：取消旋律 + 清 boost 集合 + dispatch POWER_OFF。
-      // 不响 click：电源键自身的"咔哒"是物理动作，不该触发 buzzer
-      if (kind === 'press' && button === 'Start') {
-        melodyCancelRef.current?.();
-        melodyCancelRef.current = null;
-        pressedBoostRef.current.clear();
-        setBoost(false);
-        dispatch({ type: 'POWER_OFF' });
-        return;
+
+      // 关机状态：除上面 Start 已处理外，其它按键一律无响应
+      if (modeRef.current === 'off') return;
+
+      // 暂停态拦截游戏键 —— 不让 onButton 改 game state。Reset 已在上面先放行 +
+      // 清了 pause，到这里 ctx.pause.value 已经是 false 不会被拦
+      if (ctx.pause.value && modeRef.current === 'playing') {
+        switch (button) {
+          case 'Up':
+          case 'Down':
+          case 'Left':
+          case 'Right':
+          case 'A':
+          case 'B':
+            return;
+        }
       }
-      // Sound 键：先 toggle 再 play —— "切到 ON 那一下"听到 click 反馈；
-      // 切到 OFF 时 masterGain 已被静音，play 调度的 click 听不见
-      if (kind === 'press' && button === 'Sound') {
-        ctx.soundOn.toggle();
+
+      // 游戏键反馈音：press 和 repeat 都响，让加速期间有"嘀嘀嘀"连击反馈
+      // （对齐 react-tetris move 音节奏）。release 不响（松开本来就没声）。
+      // Reset 不响（控制键已在前面单独处理）
+      if ((kind === 'press' || kind === 'repeat') && button !== 'Reset') {
         ctx.sound.play('move');
-        return;
       }
-      // 其它按键（方向键 / Rotate / Reset）：走 reducer。Reset 由 reducer 在
-      // playing 模式实现"回 select 菜单"；Reset 自身不响 click，其它都响
-      if (kind === 'press' && button !== 'Reset') ctx.sound.play('move');
-      // 开机动画期间任意键先打断旋律，dispatch INPUT 让 reducer 切到 select
+
+      // 开机动画期间任意 press 先打断旋律
       if (kind === 'press' && modeRef.current === 'boot') {
         melodyCancelRef.current?.();
         melodyCancelRef.current = null;
       }
-      // 加速键集合维护：press 加入，release 移除；集合非空 ↔ boost on
-      if (BOOST_KEYS.has(button)) {
-        if (kind === 'press') pressedBoostRef.current.add(button);
-        else pressedBoostRef.current.delete(button);
-        const next = pressedBoostRef.current.size > 0;
-        setBoost((prev) => (prev === next ? prev : next));
-      }
+
       dispatch({ type: 'INPUT', button, kind });
     });
     return () => {
@@ -349,25 +369,22 @@ export function App(): React.ReactElement {
   // ticker 速度跟着 mode / 当前游戏 / 是否 game over 走。
   // playing 态优先用 game.tickSpeeds[speed-1]，回退到 game.tickSpeed，
   // 都没有就沿用开机动画速度（说明这款游戏不关心 tick 节奏）。
-  // boost=true 时整体 × BOOST_FACTOR；死亡动画期间不加速（GAME_OVER 固定速度
-  // 是动画节奏，不能变）
+  // 加速由各游戏自身在 onButton 内处理（如 Snake 的"按键即走 + 跳一次
+  // 自然 tick"），App 层不再统一提频
   useEffect(() => {
     if (state.mode === 'playing' && state.playingId) {
       const game = registry.get(state.playingId);
       const isOver = game?.isGameOver?.(state.gameState) ?? false;
+      // 游戏内动画态优先用 ANIM_TICK_SPEED；isGameOver=true 时也视为动画
+      // （Snake 不必单独实现 isAnimating，省一次样板代码）
+      const isAnimating = isOver || (game?.isAnimating?.(state.gameState) ?? false);
       const baseSpeed =
         game?.tickSpeeds?.[state.menu.speed - 1] ?? game?.tickSpeed ?? BOOT_TICK_SPEED;
-      // 优先级：死亡动画速度 > 加速倍率 > 基础速度
-      const effectiveSpeed = isOver
-        ? GAME_OVER_ANIM_SPEED
-        : boost
-          ? baseSpeed * BOOST_FACTOR
-          : baseSpeed;
-      ctx.ticker.setSpeed(effectiveSpeed);
+      ctx.ticker.setSpeed(isAnimating ? ANIM_TICK_SPEED : baseSpeed);
     } else {
       ctx.ticker.setSpeed(BOOT_TICK_SPEED);
     }
-  }, [state.mode, state.playingId, state.gameState, state.menu.speed, boost, ctx.ticker, registry]);
+  }, [state.mode, state.playingId, state.gameState, state.menu.speed, ctx.ticker, registry]);
 
   // 屏幕渲染
   useEffect(() => {
@@ -428,6 +445,21 @@ export function App(): React.ReactElement {
     useMemo(() => () => ctx.soundOn.value, [ctx.soundOn])
   );
 
+  const paused = useSyncExternalStore(
+    useMemo(() => (notify: () => void) => ctx.pause.subscribe(notify), [ctx.pause]),
+    useMemo(() => () => ctx.pause.value, [ctx.pause])
+  );
+
+  // 暂停状态接 ticker —— playing+paused 时停掉 tick 调度，否则恢复。其它
+  // mode（off/boot/select）不参与 pause 语义；boot 动画始终跑，不让 P 键打断
+  useEffect(() => {
+    if (state.mode === 'playing' && paused) {
+      ctx.ticker.pause();
+    } else {
+      ctx.ticker.resume();
+    }
+  }, [state.mode, paused, ctx.ticker]);
+
   // 本局分数超越 hi-score 时推进。用 ref 式同步调用是安全的：
   // createCounter.set 在值未变时不通知，不会反向触发 score 订阅造成循环。
   useEffect(() => {
@@ -447,6 +479,7 @@ export function App(): React.ReactElement {
             speed={state.menu.speed}
             level={state.menu.level}
             selectMode={state.mode === 'select'}
+            pauseMode={paused}
             soundOn={soundOn}
           />
         }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -478,7 +478,6 @@ export function App(): React.ReactElement {
             hiScore={hiScore}
             speed={state.menu.speed}
             level={state.menu.level}
-            selectMode={state.mode === 'select'}
             pauseMode={paused}
             soundOn={soundOn}
           />

--- a/src/engine/__tests__/input.test.ts
+++ b/src/engine/__tests__/input.test.ts
@@ -16,14 +16,18 @@ describe('createInputBus', () => {
     expect(spy).toHaveBeenCalledExactlyOnceWith('Up', 'press');
   });
 
-  it('重复 press 同一按键不会重复通知', () => {
+  it('重复 press 同一按键仍通知（让 OS key repeat 序列穿透到订阅者）', () => {
     const bus = createInputBus();
     const spy = vi.fn();
     bus.subscribe(spy);
     bus.emit('A', 'press');
     bus.emit('A', 'press');
     bus.emit('A', 'press');
-    expect(spy).toHaveBeenCalledTimes(1);
+    // press 不去重：调用者收到 3 次通知
+    expect(spy).toHaveBeenCalledTimes(3);
+    // pressed 集合幂等：重复 press 不让 size 变大
+    expect(bus.pressed.has('A')).toBe(true);
+    expect(bus.pressed.size).toBe(1);
   });
 
   it('release 让按键离开 pressed 集合', () => {

--- a/src/engine/input.ts
+++ b/src/engine/input.ts
@@ -7,9 +7,12 @@ import type { Button, ButtonAction, InputBus, Unsubscribe } from './types';
  * 具体输入源由上层适配器调用 `emit(btn, action)` 注入。
  *
  * 语义要点：
- * - 重复 press 同一个按键不会重复通知
- * - release 未被 press 的按键是 no-op
- * - `pressed` 是 live ReadonlySet，订阅者可直接查询当前状态
+ * - press   每次都通知订阅者；同时把按键加入 pressed 集合（幂等）
+ * - repeat  平台层在 press 后按固定节奏 emit 的"长按重复"信号；fire 订阅者
+ *           但不动 pressed 集合（pressed 反映"是否被按住"，与"是否在重复"无关）
+ * - release 仅当 pressed 集合内有该键时通知（防御性，过滤无 press 的 release）
+ *
+ * `pressed` live ReadonlySet 反映"当前是否处于按下态"，订阅者可查询
  */
 export function createInputBus(): InputBus {
   const pressed = new Set<Button>();
@@ -17,12 +20,17 @@ export function createInputBus(): InputBus {
 
   return {
     emit(btn: Button, action: ButtonAction): void {
-      if (action === 'press') {
-        if (pressed.has(btn)) return;
-        pressed.add(btn);
-      } else {
-        if (!pressed.has(btn)) return;
-        pressed.delete(btn);
+      switch (action) {
+        case 'press':
+          pressed.add(btn);
+          break;
+        case 'repeat':
+          // 不动 pressed 集合：repeat 不算"新按下"
+          break;
+        case 'release':
+          if (!pressed.has(btn)) return;
+          pressed.delete(btn);
+          break;
       }
       for (const fn of subs) fn(btn, action);
     },

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -15,11 +15,19 @@ export type Button =
   | 'B'
   | 'Start'
   | 'Select'
+  | 'Pause'
   | 'Sound'
   | 'Reset';
 
-/** 按键动作：按下 / 抬起 */
-export type ButtonAction = 'press' | 'release';
+/**
+ * 按键动作：按下 / 长按重复 / 抬起
+ *
+ * - press   首次按下（每次"全新按键"必发）
+ * - repeat  按住超过起始延迟后由平台层按固定节奏发出；游戏自己决定响应
+ *           不响应（Snake 方向键 + A 都响应；Tetris 方向键响应、A 不响应）
+ * - release 松开
+ */
+export type ButtonAction = 'press' | 'repeat' | 'release';
 
 /** 音效标识符 —— 先给出最小集，后续游戏接入再扩展 */
 export type SoundEffect = 'move' | 'rotate' | 'clear' | 'over' | 'start' | 'pause';

--- a/src/games/__tests__/games.test.ts
+++ b/src/games/__tests__/games.test.ts
@@ -7,10 +7,17 @@ const SCREEN_W = 10;
 const SCREEN_H = 20;
 
 describe('defaultGames 注册表', () => {
-  it('包含 2 款占位游戏（A01 Snake / A02 Tetris）', () => {
+  it('包含 2 款已实现游戏（A01 Snake / A02 Tetris）', () => {
     expect(defaultGames.size).toBe(2);
     const ids = defaultGames.list().map((g) => g.id);
     expect(ids).toEqual(['snake', 'tetris']);
+    // 两款都已脱离占位状态，init / step / render / onButton 全实现
+    for (const g of defaultGames.list()) {
+      expect(typeof g.init).toBe('function');
+      expect(typeof g.step).toBe('function');
+      expect(typeof g.render).toBe('function');
+      expect(typeof g.onButton).toBe('function');
+    }
   });
 
   it('每款游戏的 preview 所有坐标都落在 10×20 屏幕内', () => {

--- a/src/games/snake/__tests__/snake.test.ts
+++ b/src/games/snake/__tests__/snake.test.ts
@@ -29,6 +29,7 @@ function makeState(partial: Partial<SnakeState>): SnakeState {
     awaitingFirstMove: false,
     score: 0,
     lastOpts: null,
+    skipNextTick: false,
     ...partial,
   };
 }
@@ -397,10 +398,12 @@ describe('snake · onButton', () => {
     expect(onButton(env, base, 'Left', 'press')).toBe(base);
   });
 
-  it('release 与非方向键 无副作用', () => {
+  it('release 无副作用 / 非方向键非 A 无副作用', () => {
     const env = makeEnv();
     expect(onButton(env, base, 'Up', 'release')).toBe(base);
-    expect(onButton(env, base, 'A', 'press')).toBe(base);
+    // 'B' 不在 onButton 处理范围，返回原 state
+    expect(onButton(env, base, 'B', 'press')).toBe(base);
+    // A 不是 release 时会触发"沿当前方向走一格"，单独测试见下面"A 键 Rotate"
   });
 
   it('over 态下按键不生效', () => {
@@ -431,5 +434,119 @@ describe('snake · onButton', () => {
     const s1 = onButton(env, idle, 'A', 'press');
     expect(s1.awaitingFirstMove).toBe(false);
     expect(s1.dir).toBe('right');
+  });
+});
+
+describe('snake · 按键即走（真机加速模式）', () => {
+  it('方向键 press 立即推进一格 + 设 skipNextTick=true', () => {
+    const env = makeEnv();
+    const s0 = makeState({
+      body: [
+        [4, 10],
+        [3, 10],
+        [2, 10],
+      ],
+      dir: 'right',
+      pendingDir: 'right',
+    });
+    // 按右：同向键也触发立即推进
+    const s1 = onButton(env, s0, 'Right', 'press');
+    expect(s1.body[0]).toEqual([5, 10]);
+    expect(s1.body).toHaveLength(3);
+    expect(s1.skipNextTick).toBe(true);
+    expect(s1.dir).toBe('right');
+  });
+
+  it('按异向键：改向 + 立即推进 + skipNextTick=true', () => {
+    const env = makeEnv();
+    const s0 = makeState({
+      body: [
+        [4, 10],
+        [3, 10],
+      ],
+      dir: 'right',
+      pendingDir: 'right',
+    });
+    const s1 = onButton(env, s0, 'Up', 'press');
+    expect(s1.dir).toBe('up');
+    expect(s1.pendingDir).toBe('up');
+    expect(s1.body[0]).toEqual([4, 9]);
+    expect(s1.skipNextTick).toBe(true);
+  });
+
+  it('反向键被拒：不推进、skipNextTick 不变', () => {
+    const env = makeEnv();
+    const s0 = makeState({
+      body: [
+        [4, 10],
+        [3, 10],
+      ],
+      dir: 'right',
+      pendingDir: 'right',
+    });
+    const s1 = onButton(env, s0, 'Left', 'press');
+    expect(s1).toBe(s0);
+  });
+
+  it('skipNextTick=true 时 step 跳过一次推进 + 重置 skipNextTick=false', () => {
+    const env = makeEnv();
+    const s0 = makeState({
+      body: [
+        [4, 10],
+        [3, 10],
+      ],
+      skipNextTick: true,
+    });
+    const s1 = step(env, s0);
+    expect(s1.body).toEqual(s0.body);
+    expect(s1.skipNextTick).toBe(false);
+  });
+
+  it('A 键（Rotate）：沿当前方向走一格（不改向）+ skipNextTick=true', () => {
+    const env = makeEnv();
+    const s0 = makeState({
+      body: [
+        [4, 10],
+        [3, 10],
+        [2, 10],
+      ],
+      dir: 'right',
+      pendingDir: 'right',
+    });
+    const s1 = onButton(env, s0, 'A', 'press');
+    expect(s1.body[0]).toEqual([5, 10]);
+    expect(s1.dir).toBe('right');
+    expect(s1.skipNextTick).toBe(true);
+  });
+
+  it('release 方向键清 skipNextTick：解决松开后第一次 ticker tick 被跳过的停顿', () => {
+    const env = makeEnv();
+    const s0 = makeState({
+      body: [[5, 10]],
+      dir: 'right',
+      pendingDir: 'right',
+      skipNextTick: true,
+    });
+    const s1 = onButton(env, s0, 'Right', 'release');
+    expect(s1.skipNextTick).toBe(false);
+  });
+
+  it('release 时 skipNextTick=false 已经是 false，返回同引用避免无谓渲染', () => {
+    const env = makeEnv();
+    const s0 = makeState({ skipNextTick: false });
+    expect(onButton(env, s0, 'Right', 'release')).toBe(s0);
+  });
+
+  it('按键即走撞墙：over=true，不设 skipNextTick（over 路径下 step 走动画推进）', () => {
+    const env = makeEnv();
+    const s0 = makeState({
+      body: [[9, 10]],
+      dir: 'right',
+      pendingDir: 'right',
+    });
+    // 按右键立即推进会撞右墙
+    const s1 = onButton(env, s0, 'Right', 'press');
+    expect(s1.over).toBe(true);
+    expect(s1.skipNextTick).toBe(false);
   });
 });

--- a/src/games/snake/index.ts
+++ b/src/games/snake/index.ts
@@ -7,12 +7,12 @@ import type { SnakeState } from './state';
 /**
  * 9 档起始 tick 速度（ticks/second）。
  *
- * speed=2（1.25）保留旧版本默认手感作为基线；档位间不是等差也不是
- * 等比 —— 低档段 +25% 步进（让初学玩家感受得到差距但不至于劝退），
- * 高档段 +33%~+50%（专家档逐档明显加快）。speed=9 (6 ticks/s ≈ 167ms)
- * 接近 Brick Game 真机的最快 Snake 节奏。
+ * speed=2（1.5）保留接近旧版本默认手感作为基线；档位间不是等差也不是
+ * 等比 —— 低档段 +25%~50% 步进，高档段 +30%~50%（专家档逐档明显加快）。
+ * speed=9 (10 ticks/s = 100ms) 接近 Brick Game 真机最快 Snake 节奏，
+ * 配合长按 repeat 节奏达到极限手感
  */
-const SNAKE_TICK_SPEEDS: readonly number[] = [1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 6];
+const SNAKE_TICK_SPEEDS: readonly number[] = [1, 1.5, 2, 2.5, 3.5, 4.5, 6, 8, 10];
 
 export const snake: Game<SnakeState> = {
   id: 'snake',

--- a/src/games/snake/logic.ts
+++ b/src/games/snake/logic.ts
@@ -40,7 +40,7 @@ const CRASH_STATES: ReadonlyArray<ReadonlyArray<ReadonlyArray<number>>> = [
 
 /** 每个爆炸图案在屏幕上停留的 tick 数（<=1 视为每 tick 切图） */
 const CRASH_PHASE_FRAMES = 2;
-/** 爆炸阶段总帧数：30 帧（按 App 的 GAME_OVER_ANIM_SPEED=30 即 1s）*/
+/** 爆炸阶段总帧数：30 帧（按 App 的 ANIM_TICK_SPEED=30 即 1s）*/
 const CRASH_PAINT_FRAMES = 30;
 /** 填屏阶段帧数：屏高 H=20，每帧填 1 行，共 20 帧 */
 const CRASH_FILL_FRAMES = 20;
@@ -90,6 +90,7 @@ export function init(env: GameEnv, opts?: GameInitOptions): SnakeState {
     awaitingFirstMove: true,
     score: 0,
     lastOpts: opts ?? null,
+    skipNextTick: false,
   };
 }
 
@@ -114,6 +115,22 @@ export function step(env: GameEnv, state: SnakeState): SnakeState {
   // 等待玩家按键启动：step 不推进蛇，画面静止在初始姿态
   if (state.awaitingFirstMove) return state;
 
+  // 按键即走的补偿：onButton 已经手动推进一格，跳过这次自然 tick
+  if (state.skipNextTick) {
+    return { ...state, skipNextTick: false };
+  }
+
+  return advance(env, state);
+}
+
+/**
+ * 把蛇沿 pendingDir 推进一格 + 处理墙 / 自撞 / 吃食物 / 通关。
+ *
+ * 抽出这个函数让 step（ticker tick 触发）和 onButton（按键即走）共享同一段
+ * 移动 + 碰撞 + 食物逻辑，避免在两处重复实现。所有副作用（env.score.set /
+ * env.sound.play）都集中在这里
+ */
+function advance(env: GameEnv, state: SnakeState): SnakeState {
   const head = state.body[0];
   if (!head) return state;
 
@@ -252,28 +269,45 @@ export function render(env: GameEnv, state: SnakeState): void {
   }
 }
 
+/** 把 Button 翻译成 Direction；非方向键返回 null */
+function buttonToDir(btn: Button): Direction | null {
+  switch (btn) {
+    case 'Up':
+      return 'up';
+    case 'Down':
+      return 'down';
+    case 'Left':
+      return 'left';
+    case 'Right':
+      return 'right';
+    default:
+      return null;
+  }
+}
+
 export function onButton(
-  _env: GameEnv,
+  env: GameEnv,
   state: SnakeState,
   btn: Button,
   action: ButtonAction
 ): SnakeState {
-  if (action !== 'press' || state.over) return state;
+  if (state.over) return state;
 
-  const nextDir: Direction | null =
-    btn === 'Up'
-      ? 'up'
-      : btn === 'Down'
-        ? 'down'
-        : btn === 'Left'
-          ? 'left'
-          : btn === 'Right'
-            ? 'right'
-            : null;
+  switch (action) {
+    case 'release':
+      // 方向键松开后清 skipNextTick：长按期间最后一次 repeat 留下了 skipNextTick=true，
+      // 如果不清，松开后第一次自然 ticker tick 会被跳过 → 玩家感觉"松开后停顿一拍才走"
+      return state.skipNextTick ? { ...state, skipNextTick: false } : state;
+    case 'press':
+    case 'repeat':
+      break;
+  }
 
-  // 等待启动：任意 press 解除等待。方向键同时改向（反向键被拒，不解除等待，
-  // 让玩家有机会再按一次正向键）。按键反馈音由 App 层统一发，这里不重复 play
+  const nextDir = buttonToDir(btn);
+
+  // 等待启动：仅 press 解除等待，repeat 状态下还停在初始姿态没意义
   if (state.awaitingFirstMove) {
+    if (action !== 'press') return state;
     if (nextDir && isOpposite(state.dir, nextDir)) return state;
     return {
       ...state,
@@ -283,9 +317,27 @@ export function onButton(
     };
   }
 
-  if (!nextDir) return state;
-  if (isOpposite(state.dir, nextDir)) return state;
-  return { ...state, pendingDir: nextDir };
+  // 按键即走：press 和 repeat 都触发"沿目标方向走一格"。Brick-Game 真机
+  // 的 Rotate (A) 在 Snake 里等价于"沿当前方向走一步"，所以也走这条路径
+  switch (btn) {
+    case 'Up':
+    case 'Down':
+    case 'Left':
+    case 'Right': {
+      if (!nextDir || isOpposite(state.dir, nextDir)) return state;
+      const turned: SnakeState = { ...state, pendingDir: nextDir };
+      const moved = advance(env, turned);
+      if (moved.over) return moved;
+      return { ...moved, skipNextTick: true };
+    }
+    case 'A': {
+      const moved = advance(env, state);
+      if (moved.over) return moved;
+      return { ...moved, skipNextTick: true };
+    }
+    default:
+      return state;
+  }
 }
 
 export function isGameOver(state: SnakeState): boolean {

--- a/src/games/snake/state.ts
+++ b/src/games/snake/state.ts
@@ -55,6 +55,19 @@ export interface SnakeState {
    * "原样传回"避免重置成默认 1/1。null 表示从未传入 opts（极少数场景）。
    */
   readonly lastOpts: GameInitOptions | null;
+  /**
+   * "按键即走"补偿标记：onButton 处理方向键时手动推进一格，并把这个标记
+   * 置 true 让紧接着的下一次 step 跳过一次自然推进。
+   *
+   * 行为目的：模拟 Brick Game 真机的按键加速 —— 长按方向键时浏览器持续
+   * 触发 keydown，每次都立即推进一格 + 跳过下一 tick，蛇的移动节奏 ≈
+   * 浏览器 key repeat 频率（通常 30–50ms / 次），比 baseline tick 快得多。
+   * 松开后回到自然 tick 节奏，无 lingering 加速。
+   *
+   * 与 App 层"按住键 ticker × 3"模式相比，按键即走的视觉手感更接近真机：
+   * 按下瞬间反馈、松开立即恢复，没有"加速持续期"
+   */
+  readonly skipNextTick: boolean;
 }
 
 const DIR_VEC: Readonly<Record<Direction, Pixel>> = {

--- a/src/games/tetris/__tests__/tetris.test.ts
+++ b/src/games/tetris/__tests__/tetris.test.ts
@@ -1,0 +1,428 @@
+import { describe, expect, it } from 'vitest';
+
+import { createHeadlessContext } from '@/platform/headless';
+import { type GameEnv, toGameEnv } from '@/sdk';
+
+import { init, isAnimating, isGameOver, onButton, render, step } from '../logic';
+import {
+  type ActivePiece,
+  FIELD_HEIGHT,
+  FIELD_WIDTH,
+  isValidPosition,
+  pieceCells,
+  TETROMINOES,
+  type TetrisState,
+} from '../state';
+
+function makeEnv(seed = 42): GameEnv {
+  return toGameEnv(createHeadlessContext({ seed, width: FIELD_WIDTH, height: FIELD_HEIGHT }));
+}
+
+/** 用空 grid 起手 state，便于测特定形态 */
+function emptyState(partial: Partial<TetrisState> = {}): TetrisState {
+  return {
+    grid: new Array<number>(FIELD_WIDTH * FIELD_HEIGHT).fill(0),
+    active: { kind: 'T', rotation: 0, x: 3, y: 0 },
+    next: 'I',
+    awaitingFirstMove: false,
+    over: false,
+    overFrame: 0,
+    clearingLines: [],
+    clearFrame: 0,
+    score: 0,
+    lines: 0,
+    lastOpts: null,
+    ...partial,
+  };
+}
+
+/**
+ * 用 ASCII 画面构造 grid，省去手算一维下标的痛苦。
+ *
+ *   gridFromAscii(`
+ *     ..........
+ *     ..........
+ *     XXX.XXXXXX
+ *     XXXXXXXXXX
+ *   `)
+ *
+ * - 'X' / '#' = 砖 (1)，'.' / ' ' = 空 (0)
+ * - 行数 < FIELD_HEIGHT 时上方自动补空行
+ * - 每行宽度必须 === FIELD_WIDTH
+ */
+function gridFromAscii(ascii: string): number[] {
+  const rows = ascii
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  const padded = [
+    ...Array.from<string>({ length: FIELD_HEIGHT - rows.length }).fill('.'.repeat(FIELD_WIDTH)),
+    ...rows,
+  ];
+  return padded.flatMap((row) => [...row].map((ch) => (ch === 'X' || ch === '#' ? 1 : 0)));
+}
+
+/** 推进若干 tick；用于跨越消行闪烁等多帧动画 */
+function advanceTicks(env: ReturnType<typeof makeEnv>, s: TetrisState, n: number): TetrisState {
+  let cur = s;
+  for (let i = 0; i < n; i++) cur = step(env, cur);
+  return cur;
+}
+
+describe('tetris · state helpers', () => {
+  it('每种方块的 4 个旋转相位都恰好 4 格', () => {
+    for (const kind of Object.keys(TETROMINOES) as (keyof typeof TETROMINOES)[]) {
+      for (const rot of TETROMINOES[kind]) {
+        expect(rot).toHaveLength(4);
+      }
+    }
+  });
+
+  it('isValidPosition 越界 / 撞已锁砖块 返回 false', () => {
+    const grid = new Array<number>(FIELD_WIDTH * FIELD_HEIGHT).fill(0);
+    // 撞底
+    expect(
+      isValidPosition(grid, FIELD_WIDTH, FIELD_HEIGHT, {
+        kind: 'I',
+        rotation: 0,
+        x: 0,
+        y: FIELD_HEIGHT - 1,
+      })
+    ).toBe(false);
+    // 撞右墙
+    expect(
+      isValidPosition(grid, FIELD_WIDTH, FIELD_HEIGHT, {
+        kind: 'O',
+        rotation: 0,
+        x: FIELD_WIDTH - 1,
+        y: 0,
+      })
+    ).toBe(false);
+    // 撞已锁砖块
+    const grid2 = grid.slice();
+    grid2[5 * FIELD_WIDTH + 4] = 1;
+    expect(
+      isValidPosition(grid2, FIELD_WIDTH, FIELD_HEIGHT, {
+        kind: 'O',
+        rotation: 0,
+        x: 4,
+        y: 4,
+      })
+    ).toBe(false);
+  });
+
+  it('pieceCells 给出锚点 + rotation 的绝对坐标', () => {
+    const piece: ActivePiece = { kind: 'I', rotation: 0, x: 2, y: 5 };
+    const cells = pieceCells(piece);
+    // I 0 形：[0,1][1,1][2,1][3,1]，+ 锚点 (2,5)
+    expect(cells).toEqual([
+      [2, 6],
+      [3, 6],
+      [4, 6],
+      [5, 6],
+    ]);
+  });
+});
+
+describe('tetris · init', () => {
+  it('初始：grid 全 0，active 与 next 已生成，awaitingFirstMove=true，score=0', () => {
+    const env = makeEnv();
+    const s = init(env);
+    expect(s.grid).toHaveLength(FIELD_WIDTH * FIELD_HEIGHT);
+    expect(s.grid.every((c) => c === 0)).toBe(true);
+    expect(s.active).not.toBeNull();
+    expect(s.next).toBeTruthy();
+    expect(s.awaitingFirstMove).toBe(true);
+    expect(s.over).toBe(false);
+    expect(s.score).toBe(0);
+    expect(s.lines).toBe(0);
+    expect(env.score.value).toBe(0);
+  });
+
+  it('init 接收 opts 透传到 lastOpts', () => {
+    const env = makeEnv();
+    const s = init(env, { speed: 7, level: 3 });
+    expect(s.lastOpts).toEqual({ speed: 7, level: 3 });
+  });
+
+  it('init 不传 opts 时 lastOpts=null', () => {
+    const env = makeEnv();
+    const s = init(env);
+    expect(s.lastOpts).toBeNull();
+  });
+});
+
+describe('tetris · step', () => {
+  it('awaitingFirstMove=true 时 step 不让方块下落', () => {
+    const env = makeEnv();
+    const s0 = emptyState({ awaitingFirstMove: true });
+    expect(step(env, s0)).toBe(s0);
+  });
+
+  it('正常下落：active.y +1', () => {
+    const env = makeEnv();
+    const s0 = emptyState({ active: { kind: 'T', rotation: 0, x: 3, y: 5 } });
+    const s1 = step(env, s0);
+    expect(s1.active?.y).toBe(6);
+  });
+
+  it('落到底无法再下：锁定 + spawn 新方块（active 换种类）', () => {
+    const env = makeEnv();
+    // T 方块靠底（rotation=0 高度 2 行）；y=18 时 cells 落在 y=18,19，再下走到 y=19,20 越界
+    const s0 = emptyState({
+      active: { kind: 'T', rotation: 0, x: 3, y: 18 },
+      next: 'O',
+    });
+    const s1 = step(env, s0);
+    // 原 T 已锁进 grid（4 个格点）
+    const onCount = s1.grid.filter((c) => c === 1).length;
+    expect(onCount).toBe(4);
+    // 新 active 是之前的 next (O)
+    expect(s1.active?.kind).toBe('O');
+  });
+
+  it('单消得 1 分 → 进入闪烁阶段（score 立即更新，grid 暂留）', () => {
+    const env = makeEnv();
+    // T rotation=0 锁在 y=18,19 → 补齐底行 x=3,4,5
+    const grid = gridFromAscii(`
+      XXX...XXXX
+    `);
+    const s0 = emptyState({
+      grid,
+      active: { kind: 'T', rotation: 0, x: 3, y: 18 },
+    });
+    const s1 = step(env, s0);
+    expect(s1.score).toBe(1);
+    expect(s1.lines).toBe(1);
+    expect(env.score.value).toBe(1);
+    expect(s1.clearingLines).toEqual([FIELD_HEIGHT - 1]);
+    expect(s1.active).toBeNull();
+    expect(s1.grid[(FIELD_HEIGHT - 1) * FIELD_WIDTH + 3]).toBe(1);
+  });
+
+  it('消行闪烁播完后真正消除并 spawn 下一块', () => {
+    const env = makeEnv();
+    const grid = gridFromAscii(`
+      XXX...XXXX
+    `);
+    const s0 = emptyState({
+      grid,
+      active: { kind: 'T', rotation: 0, x: 3, y: 18 },
+      next: 'O',
+    });
+    const sFinal = advanceTicks(env, s0, 1 + 15 + 1);
+    expect(sFinal.clearingLines).toEqual([]);
+    expect(sFinal.active?.kind).toBe('O');
+    // T 锁在 y=18 的那行经消行后下移到 y=19（底行被消掉腾出空间）
+    expect(sFinal.grid[(FIELD_HEIGHT - 1) * FIELD_WIDTH + 4]).toBe(1);
+  });
+
+  it('双消得 3 分', () => {
+    const env = makeEnv();
+    // O 方块 (0,18)(1,18)(0,19)(1,19) 补齐两行
+    const grid = gridFromAscii(`
+      ..XXXXXXXX
+      ..XXXXXXXX
+    `);
+    const s0 = emptyState({
+      grid,
+      active: { kind: 'O', rotation: 0, x: 0, y: 18 },
+    });
+    const s1 = step(env, s0);
+    expect(s1.score).toBe(3);
+    expect(s1.lines).toBe(2);
+    expect(s1.clearingLines).toEqual([FIELD_HEIGHT - 2, FIELD_HEIGHT - 1]);
+  });
+
+  it('三消得 5 分', () => {
+    const env = makeEnv();
+    // I rotation=1 竖着占 (2,0~3)；把底部 3 行 x=2 留空，I 落下补齐
+    const grid = gridFromAscii(`
+      XX.XXXXXXX
+      XX.XXXXXXX
+      XX.XXXXXXX
+    `);
+    const s0 = emptyState({
+      grid,
+      active: { kind: 'I', rotation: 1, x: 0, y: 16 },
+    });
+    const s1 = step(env, s0);
+    expect(s1.score).toBe(5);
+    expect(s1.lines).toBe(3);
+    expect(s1.clearingLines).toHaveLength(3);
+  });
+
+  it('Tetris（四消）得 8 分', () => {
+    const env = makeEnv();
+    // I rotation=1 竖着占 x=2, y=16~19；底部 4 行 x=2 留空
+    const grid = gridFromAscii(`
+      XX.XXXXXXX
+      XX.XXXXXXX
+      XX.XXXXXXX
+      XX.XXXXXXX
+    `);
+    const s0 = emptyState({
+      grid,
+      active: { kind: 'I', rotation: 1, x: 0, y: 16 },
+    });
+    const s1 = step(env, s0);
+    expect(s1.score).toBe(8);
+    expect(s1.lines).toBe(4);
+    expect(s1.clearingLines).toHaveLength(4);
+  });
+
+  it('消行后上方砖块正确下落填补空位', () => {
+    const env = makeEnv();
+    // y=18 孤砖 x=0；y=19 缺 x=8,9。O(8,18) 补齐底行触发消行
+    const grid = gridFromAscii(`
+      X.........
+      XXXXXXXX..
+    `);
+    const s0 = emptyState({
+      grid,
+      active: { kind: 'O', rotation: 0, x: 8, y: 18 },
+      next: 'T',
+    });
+    // 1 tick 锁定 + 进闪烁，15 tick 闪烁，1 tick 真正消除 = 17
+    const sFinal = advanceTicks(env, s0, 1 + 15 + 1);
+    // 底行被消后，原 y=18 的孤砖 (0,18) 下移到 (0,19)
+    expect(sFinal.grid[(FIELD_HEIGHT - 1) * FIELD_WIDTH + 0]).toBe(1);
+    expect(sFinal.clearingLines).toEqual([]);
+  });
+
+  it('spawn 即非法 → over=true，overFrame=0', () => {
+    const env = makeEnv();
+    // 顶行非满但堵住 spawn 落点：I (rotation=0) 出生 cells (3,0)(4,0)(5,0)(6,0)。
+    // 把 (3,0)(4,0)(5,0)(6,0) 单独堵上，避免顶行被锁定后消空
+    const grid = new Array<number>(FIELD_WIDTH * FIELD_HEIGHT).fill(0);
+    for (const x of [3, 4, 5, 6]) grid[0 * FIELD_WIDTH + x] = 1;
+    // 当前 active 落到底锁定 + 触发 spawn next=I，I 出生撞 (3..6, 0) → over
+    const s0 = emptyState({
+      grid,
+      active: { kind: 'O', rotation: 0, x: 4, y: 18 }, // 已经在底，下一 step 锁定
+      next: 'I',
+    });
+    const s1 = step(env, s0);
+    expect(s1.over).toBe(true);
+    expect(s1.overFrame).toBe(0);
+    expect(s1.active).toBeNull();
+  });
+
+  it('over 态推进 overFrame；动画播完后 step 调 init 重开（保留 lastOpts）', () => {
+    const env = makeEnv();
+    const s0 = emptyState({
+      over: true,
+      overFrame: 0,
+      lastOpts: { speed: 5, level: 2 },
+    });
+    const s1 = step(env, s0);
+    expect(s1.overFrame).toBe(1);
+    // 推到最后一帧再 + 1 应该重开
+    const sFinal = emptyState({
+      over: true,
+      overFrame: FIELD_HEIGHT * 2,
+      lastOpts: { speed: 5, level: 2 },
+    });
+    const reborn = step(env, sFinal);
+    expect(reborn.over).toBe(false);
+    expect(reborn.awaitingFirstMove).toBe(true);
+    expect(reborn.lastOpts).toEqual({ speed: 5, level: 2 });
+  });
+});
+
+describe('tetris · onButton', () => {
+  it('awaitingFirstMove=true：任意 press 解除等待，不改 active', () => {
+    const env = makeEnv();
+    const idle = emptyState({ awaitingFirstMove: true });
+    const s = onButton(env, idle, 'A', 'press');
+    expect(s.awaitingFirstMove).toBe(false);
+    expect(s.active).toBe(idle.active);
+  });
+
+  it('Left/Right 横移 active', () => {
+    const env = makeEnv();
+    const s0 = emptyState({ active: { kind: 'T', rotation: 0, x: 3, y: 5 } });
+    expect(onButton(env, s0, 'Right', 'press').active?.x).toBe(4);
+    expect(onButton(env, s0, 'Left', 'press').active?.x).toBe(2);
+  });
+
+  it('A 键旋转 active；rotation 顺时针 +1', () => {
+    const env = makeEnv();
+    const s0 = emptyState({ active: { kind: 'T', rotation: 0, x: 3, y: 5 } });
+    const s1 = onButton(env, s0, 'A', 'press');
+    expect(s1.active?.rotation).toBe(1);
+  });
+
+  it('Up 键也旋转 active（与 A 同语义）', () => {
+    const env = makeEnv();
+    const s0 = emptyState({ active: { kind: 'T', rotation: 0, x: 3, y: 5 } });
+    const s1 = onButton(env, s0, 'Up', 'press');
+    expect(s1.active?.rotation).toBe(1);
+  });
+
+  it('Up / A 旋转仅响应 press；repeat 不持续旋转', () => {
+    const env = makeEnv();
+    const s0 = emptyState({ active: { kind: 'T', rotation: 0, x: 3, y: 5 } });
+    expect(onButton(env, s0, 'Up', 'repeat')).toBe(s0);
+    expect(onButton(env, s0, 'A', 'repeat')).toBe(s0);
+  });
+
+  it('over 态 onButton 无效', () => {
+    const env = makeEnv();
+    const s0 = emptyState({ over: true });
+    expect(onButton(env, s0, 'A', 'press')).toBe(s0);
+    expect(onButton(env, s0, 'Left', 'press')).toBe(s0);
+  });
+
+  it('release 无副作用', () => {
+    const env = makeEnv();
+    const s0 = emptyState();
+    expect(onButton(env, s0, 'Right', 'release')).toBe(s0);
+  });
+});
+
+describe('tetris · render', () => {
+  it('未结束：grid 砖块 + active 方块都画到屏上', () => {
+    const env = makeEnv();
+    const grid = new Array<number>(FIELD_WIDTH * FIELD_HEIGHT).fill(0);
+    grid[5 * FIELD_WIDTH + 2] = 1;
+    const s = emptyState({
+      grid,
+      active: { kind: 'O', rotation: 0, x: 4, y: 7 },
+    });
+    render(env, s);
+    expect(env.screen.getPixel(2, 5)).toBe(true);
+    // O 块 (4,7)(5,7)(4,8)(5,8)
+    expect(env.screen.getPixel(4, 7)).toBe(true);
+    expect(env.screen.getPixel(5, 8)).toBe(true);
+  });
+
+  it('over + 填屏阶段 1 帧：底部 1 行全亮', () => {
+    const env = makeEnv();
+    const s = emptyState({ over: true, overFrame: 0 });
+    render(env, s);
+    for (let x = 0; x < FIELD_WIDTH; x++) {
+      expect(env.screen.getPixel(x, FIELD_HEIGHT - 1)).toBe(true);
+    }
+    expect(env.screen.getPixel(0, FIELD_HEIGHT - 2)).toBe(false);
+  });
+});
+
+describe('tetris · isGameOver', () => {
+  it('返回 state.over', () => {
+    expect(isGameOver(emptyState())).toBe(false);
+    expect(isGameOver(emptyState({ over: true }))).toBe(true);
+  });
+});
+
+describe('tetris · isAnimating', () => {
+  it('正常游戏中不是动画态', () => {
+    expect(isAnimating(emptyState())).toBe(false);
+  });
+  it('消行闪烁阶段是动画态（让 App 切到 ANIM_TICK_SPEED）', () => {
+    expect(isAnimating(emptyState({ clearingLines: [19] }))).toBe(true);
+  });
+  it('over 也算动画态', () => {
+    expect(isAnimating(emptyState({ over: true }))).toBe(true);
+  });
+});

--- a/src/games/tetris/index.ts
+++ b/src/games/tetris/index.ts
@@ -1,9 +1,26 @@
 import type { Game } from '@/sdk';
 
+import { init, isAnimating, isGameOver, onButton, render, step } from './logic';
 import { tetrisPreview } from './preview';
+import type { TetrisState } from './state';
 
-export const tetris: Game = {
+/**
+ * 9 档起始 tick 速度（ticks/second）= 方块自由下落频率。
+ *
+ * speed=1 1.5 ticks/s ≈ 670ms/格（新手友好），speed=9 12 ticks/s ≈ 83ms/格
+ * 接近真机最快档。配合 Down 软降，按住 Down 可达更快的硬降级体感
+ */
+const TETRIS_TICK_SPEEDS: readonly number[] = [1.5, 2, 2.5, 3.5, 5, 7, 9, 10.5, 12];
+
+export const tetris: Game<TetrisState> = {
   id: 'tetris',
   name: 'TETRIS',
   preview: tetrisPreview,
+  tickSpeeds: TETRIS_TICK_SPEEDS,
+  init,
+  step,
+  render,
+  onButton,
+  isGameOver,
+  isAnimating,
 };

--- a/src/games/tetris/logic.ts
+++ b/src/games/tetris/logic.ts
@@ -1,0 +1,342 @@
+import type { Button, ButtonAction } from '@/engine/types';
+import type { GameEnv, GameInitOptions } from '@/sdk';
+
+import {
+  type ActivePiece,
+  FIELD_HEIGHT,
+  FIELD_WIDTH,
+  isValidPosition,
+  type PieceKind,
+  pickKind,
+  pieceCells,
+  type Rotation,
+  TETROMINOES,
+  type TetrisState,
+} from './state';
+
+/* ------------------------------------------------------------------ *
+ * 死亡动画参数（与 Snake 共享同套两阶段节奏：填屏 + 清屏）
+ *
+ * Tetris 没有"爆炸点"概念（玩家堆顶 game over，没有撞击中心），所以
+ * 略掉 Snake 的爆炸阶段，直接走"从底向上填满屏 + 从顶向下清屏"动画。
+ * 配合 App 层的 ANIM_TICK_SPEED=30 ticks/s 总时长约 1.3s
+ * ------------------------------------------------------------------ */
+
+const FILL_FRAMES = FIELD_HEIGHT;
+const CLEAR_FRAMES = FIELD_HEIGHT;
+const CLEAR_BEGIN = FILL_FRAMES;
+const TOTAL_FRAMES = CLEAR_BEGIN + CLEAR_FRAMES;
+
+/**
+ * 消行闪烁动画的 tick 数 —— 真机风格"被消除的行先闪几下"。
+ *
+ * App 检测到 isAnimating=true 时把 ticker 切到 ANIM_TICK_SPEED (30 ticks/s
+ * ≈ 33ms/帧)。15 帧 ≈ 500ms，给玩家足够视觉反馈
+ */
+const CLEAR_BLINK_FRAMES = 15;
+
+/** 出生位置：x 居中（用 I 块包围盒 4 计算），y=-1 让方块顶端从屏外滑入 */
+function spawnPiece(kind: PieceKind): ActivePiece {
+  const shape = TETROMINOES[kind][0] ?? [];
+  const minX = Math.min(...shape.map(([x]) => x));
+  const maxX = Math.max(...shape.map(([x]) => x));
+  const pieceWidth = maxX - minX + 1;
+  return {
+    kind,
+    rotation: 0,
+    x: Math.floor((FIELD_WIDTH - pieceWidth) / 2) - minX,
+    y: -1,
+  };
+}
+
+export function init(env: GameEnv, opts?: GameInitOptions): TetrisState {
+  env.score.set(0);
+  const grid = new Array<number>(FIELD_WIDTH * FIELD_HEIGHT).fill(0);
+  const first = pickKind(env.rng);
+  const next = pickKind(env.rng);
+  return {
+    grid,
+    active: spawnPiece(first),
+    next,
+    awaitingFirstMove: true,
+    over: false,
+    overFrame: 0,
+    clearingLines: [],
+    clearFrame: 0,
+    score: 0,
+    lines: 0,
+    lastOpts: opts ?? null,
+  };
+}
+
+/** 把当前 active 锁进 grid，返回新 grid（不变性：原数组不动） */
+function lockPiece(state: TetrisState): ReadonlyArray<number> {
+  if (!state.active) return state.grid;
+  const next = state.grid.slice();
+  for (const [x, y] of pieceCells(state.active)) {
+    if (y < 0 || y >= FIELD_HEIGHT || x < 0 || x >= FIELD_WIDTH) continue;
+    next[y * FIELD_WIDTH + x] = 1;
+  }
+  return next;
+}
+
+/** 扫整个 grid 找出"全是 1"的行号集合（按 y 升序） */
+function findFullRows(grid: ReadonlyArray<number>): number[] {
+  const rows: number[] = [];
+  for (let y = 0; y < FIELD_HEIGHT; y++) {
+    const rowStart = y * FIELD_WIDTH;
+    let full = true;
+    for (let x = 0; x < FIELD_WIDTH; x++) {
+      if (grid[rowStart + x] !== 1) {
+        full = false;
+        break;
+      }
+    }
+    if (full) rows.push(y);
+  }
+  return rows;
+}
+
+/**
+ * 把指定的行从 grid 移除，上方所有行下移；返回新 grid。
+ *
+ * 与 findFullRows 配对：先 find 列出待消除行号、闪烁动画期间 grid 保留不变，
+ * 动画播完后再 remove。这样消行视觉上有"满行先闪后消"的真机感
+ */
+function removeRows(
+  grid: ReadonlyArray<number>,
+  rows: ReadonlyArray<number>
+): ReadonlyArray<number> {
+  if (rows.length === 0) return grid;
+  const removeSet = new Set(rows);
+  const kept: number[] = [];
+  for (let y = 0; y < FIELD_HEIGHT; y++) {
+    if (removeSet.has(y)) continue;
+    const rowStart = y * FIELD_WIDTH;
+    for (let x = 0; x < FIELD_WIDTH; x++) {
+      kept.push(grid[rowStart + x] ?? 0);
+    }
+  }
+  const filler = new Array<number>(rows.length * FIELD_WIDTH).fill(0);
+  return [...filler, ...kept];
+}
+
+/** 消行得分：单 1 / 双 3 / 三 5 / Tetris 8 —— 鼓励 Tetris 不鼓励单消 */
+const LINE_SCORE: Record<number, number> = { 1: 1, 2: 3, 3: 5, 4: 8 };
+
+export function step(env: GameEnv, state: TetrisState): TetrisState {
+  // game over 动画推进：与 Snake 同节奏
+  if (state.over) {
+    if (state.overFrame >= TOTAL_FRAMES) {
+      return init(env, state.lastOpts ?? undefined);
+    }
+    return { ...state, overFrame: state.overFrame + 1 };
+  }
+
+  // 消行闪烁阶段：推进 clearFrame，到期后真正消除 + spawn 新方块
+  if (state.clearingLines.length > 0) {
+    if (state.clearFrame < CLEAR_BLINK_FRAMES) {
+      return { ...state, clearFrame: state.clearFrame + 1 };
+    }
+    return spawnAfter(env, state, removeRows(state.grid, state.clearingLines));
+  }
+
+  if (state.awaitingFirstMove || !state.active) return state;
+
+  // 自由下落：尝试把 active 下移 1 格；不合法则锁定 + 消行检测
+  const fallen: ActivePiece = { ...state.active, y: state.active.y + 1 };
+  if (isValidPosition(state.grid, FIELD_WIDTH, FIELD_HEIGHT, fallen)) {
+    return { ...state, active: fallen };
+  }
+
+  // 撞底：锁定 + 检测哪些行满
+  const lockedGrid = lockPiece(state);
+  const fullRows = findFullRows(lockedGrid);
+
+  if (fullRows.length === 0) {
+    // 无消行 → 直接 spawn
+    return spawnAfter(env, state, lockedGrid);
+  }
+
+  // 有消行 → 进入闪烁阶段，spawn 推迟到 clearFrame 到期。分数立即结算，
+  // 闪烁期间 SidePanel 的 score 就已经更新（视觉反馈先于 grid 真正消除）
+  const gained = LINE_SCORE[fullRows.length] ?? 0;
+  const newScore = state.score + gained;
+  const newLines = state.lines + fullRows.length;
+  if (gained > 0) env.score.set(newScore);
+
+  return {
+    ...state,
+    grid: lockedGrid,
+    active: null,
+    clearingLines: fullRows,
+    clearFrame: 0,
+    score: newScore,
+    lines: newLines,
+  };
+}
+
+/**
+ * 根据指定 grid spawn 下一块；若出生位置非法，转为 game over。
+ *
+ * 把"无消行直接 spawn"和"消行闪烁后 spawn"统一到这条路径，省 step 内
+ * 两处重复
+ */
+function spawnAfter(env: GameEnv, state: TetrisState, grid: ReadonlyArray<number>): TetrisState {
+  const newActive = spawnPiece(state.next);
+  if (!isValidPosition(grid, FIELD_WIDTH, FIELD_HEIGHT, newActive)) {
+    env.sound.play('over');
+    return {
+      ...state,
+      grid,
+      active: null,
+      next: pickKind(env.rng),
+      clearingLines: [],
+      clearFrame: 0,
+      over: true,
+      overFrame: 0,
+    };
+  }
+  return {
+    ...state,
+    grid,
+    active: newActive,
+    next: pickKind(env.rng),
+    clearingLines: [],
+    clearFrame: 0,
+  };
+}
+
+export function render(env: GameEnv, state: TetrisState): void {
+  const { screen } = env;
+  screen.clear();
+
+  if (!state.over) {
+    // 已锁定砖墙：消行闪烁阶段时，clearingLines 中的行每 6 帧一周期
+    // （3 帧亮 / 3 帧暗），制造"满行先闪两三下再消除"的真机视觉
+    const blinkOff = state.clearingLines.length > 0 && state.clearFrame % 6 >= 3;
+    const clearSet = blinkOff ? new Set(state.clearingLines) : null;
+    for (let y = 0; y < FIELD_HEIGHT; y++) {
+      if (clearSet?.has(y)) continue; // 暗帧：跳过整行不画
+      const row = y * FIELD_WIDTH;
+      for (let x = 0; x < FIELD_WIDTH; x++) {
+        if (state.grid[row + x] === 1) screen.setPixel(x, y, true);
+      }
+    }
+    // 在场方块（出生时 y=-1 的部分会被 setPixel 静默拒绝）；
+    // 消行闪烁期间 active=null，自然跳过
+    if (state.active) {
+      for (const [x, y] of pieceCells(state.active)) screen.setPixel(x, y, true);
+    }
+    return;
+  }
+
+  // 死亡动画：填屏（自底向上）→ 清屏（自顶向下）
+  if (state.overFrame < CLEAR_BEGIN) {
+    // 先画死前的砖墙，再叠加填亮行
+    for (let y = 0; y < FIELD_HEIGHT; y++) {
+      const row = y * FIELD_WIDTH;
+      for (let x = 0; x < FIELD_WIDTH; x++) {
+        if (state.grid[row + x] === 1) screen.setPixel(x, y, true);
+      }
+    }
+    const filled = Math.min(FILL_FRAMES, state.overFrame + 1);
+    const from = FIELD_HEIGHT - filled;
+    for (let y = from; y < FIELD_HEIGHT; y++) {
+      for (let x = 0; x < FIELD_WIDTH; x++) screen.setPixel(x, y, true);
+    }
+    return;
+  }
+  // 清屏：cleared 行往下保留全亮
+  const cleared = Math.min(CLEAR_FRAMES, state.overFrame - CLEAR_BEGIN + 1);
+  for (let y = cleared; y < FIELD_HEIGHT; y++) {
+    for (let x = 0; x < FIELD_WIDTH; x++) screen.setPixel(x, y, true);
+  }
+}
+
+/** 顺时针旋转一档；下一档非法时返回 null 让调用方丢弃这次旋转 */
+function tryRotate(state: TetrisState): ActivePiece | null {
+  if (!state.active) return null;
+  const nextRot = ((state.active.rotation + 1) % 4) as Rotation;
+  const candidate: ActivePiece = { ...state.active, rotation: nextRot };
+  return isValidPosition(state.grid, FIELD_WIDTH, FIELD_HEIGHT, candidate) ? candidate : null;
+}
+
+/** 横移一格（dx ±1）；非法返回 null */
+function tryShift(state: TetrisState, dx: number): ActivePiece | null {
+  if (!state.active) return null;
+  const candidate: ActivePiece = { ...state.active, x: state.active.x + dx };
+  return isValidPosition(state.grid, FIELD_WIDTH, FIELD_HEIGHT, candidate) ? candidate : null;
+}
+
+/** 立即让 active 下落一格；非法（撞底 / 撞砖）就走完整 step 触发锁定 */
+function softDrop(env: GameEnv, state: TetrisState): TetrisState {
+  if (!state.active) return state;
+  const fallen: ActivePiece = { ...state.active, y: state.active.y + 1 };
+  if (isValidPosition(state.grid, FIELD_WIDTH, FIELD_HEIGHT, fallen)) {
+    return { ...state, active: fallen };
+  }
+  // 撞底：直接走 step 路径让它完成"锁定 + 消行 + spawn"
+  return step(env, state);
+}
+
+export function onButton(
+  env: GameEnv,
+  state: TetrisState,
+  btn: Button,
+  action: ButtonAction
+): TetrisState {
+  if (state.over) return state;
+
+  // release 不做处理
+  if (action === 'release') return state;
+
+  // 等待首次按键启动：仅 press 解除等待，repeat 状态下还停着没意义
+  if (state.awaitingFirstMove) {
+    if (action !== 'press') return state;
+    return { ...state, awaitingFirstMove: false };
+  }
+  if (!state.active) return state;
+
+  switch (btn) {
+    case 'Left': {
+      // press 和 repeat 都横移
+      const moved = tryShift(state, -1);
+      return moved ? { ...state, active: moved } : state;
+    }
+    case 'Right': {
+      const moved = tryShift(state, 1);
+      return moved ? { ...state, active: moved } : state;
+    }
+    case 'Down': {
+      // 软降：press 和 repeat 都触发，长按 ≈ 10 格/s 的下落速度
+      return softDrop(env, state);
+    }
+    case 'Up':
+    case 'A': {
+      // Up 与 Rotate 都执行旋转；仅响应 press，长按持续转会让玩家无法
+      // 精确控制方块姿态。Up 在真机 Tetris 上常作"软旋转"快捷键，与 A
+      // 同语义
+      if (action !== 'press') return state;
+      const rotated = tryRotate(state);
+      return rotated ? { ...state, active: rotated } : state;
+    }
+    default:
+      return state;
+  }
+}
+
+export function isGameOver(state: TetrisState): boolean {
+  return state.over;
+}
+
+/**
+ * App 据此把 ticker 切到 ANIM_TICK_SPEED 加速动画。覆盖两类动画态：
+ * - 消行闪烁（clearingLines.length > 0）—— 否则 baseline 慢 speed 下闪烁会
+ *   长达 1~2 秒，玩家觉得卡顿
+ * - 死亡 game over 动画 —— 默认 App 已视 isGameOver=true 为动画态，这里
+ *   只是显式兜底；返回 over 让逻辑更直白
+ */
+export function isAnimating(state: TetrisState): boolean {
+  return state.over || state.clearingLines.length > 0;
+}

--- a/src/games/tetris/state.ts
+++ b/src/games/tetris/state.ts
@@ -1,0 +1,293 @@
+import type { Pixel } from '@/sdk';
+
+/**
+ * Tetris 七种方块标识符（Standard Mapping）。Brick Game 不分颜色——LCD 单色，
+ * 我们也只关心形状不关心颜色。
+ */
+export type PieceKind = 'I' | 'O' | 'T' | 'S' | 'Z' | 'J' | 'L';
+
+/** 方块旋转相位 0..3，与 SRS（Super Rotation System）顺时针计数一致 */
+export type Rotation = 0 | 1 | 2 | 3;
+
+/**
+ * 在场方块：种类 + 旋转相位 + 左上角锚点（场地坐标系，列 x、行 y）。
+ *
+ * 方块的实际占格通过 TETROMINOES[kind][rotation] 的相对偏移 + (x, y) 得到。
+ * 这种"种类 + 旋转 + 坐标"三元组而非直接存绝对格列表的设计，能让旋转 /
+ * 平移操作只改三个标量，不必为每一步重算 4 个绝对坐标
+ */
+export interface ActivePiece {
+  readonly kind: PieceKind;
+  readonly rotation: Rotation;
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * 场地宽 / 高：与 Screen 10×20 完全一致，方块直接落在屏上不必分图层。
+ *
+ * 真机 Brick Game 把"已锁定砖墙"画在 LCD 主屏，把"下一块预览"+ score
+ * 放在右侧 SidePanel。我们的 SidePanel 暂不显示 next 预览（保持 PR
+ * 体量），有需要再扩
+ */
+export const FIELD_WIDTH = 10;
+export const FIELD_HEIGHT = 20;
+
+/**
+ * Tetris 完整 state
+ *
+ * - grid：已锁定的"砖墙"，row-major 一维数组，0 = 空 / 1 = 砖
+ * - active：当前正在下落的方块；null 表示游戏未启动 / 已结束 / 消行闪烁中
+ * - next：下一块（让 spawn 时无延迟）
+ * - awaitingFirstMove：首块停在出生位置，玩家按任意键才开始重力下落
+ * - over：玩家堆到顶或 spawn 即撞 → true，进入死亡动画
+ * - overFrame：death 动画相位计数（爆炸→填屏→清屏）
+ * - clearingLines：本轮消行涉及到的行号（按 y 升序）。空 = 没在消行
+ * - clearFrame：消行闪烁阶段的 tick 计数；CLEAR_BLINK_FRAMES 到期后真正消除
+ * - score：消行数 × 分（单消 1 / 双消 3 / 三消 5 / Tetris 8）
+ * - lines：累计消行数（玩家成长指标）
+ * - lastOpts：菜单选定的 speed / level，用于死亡后自动重开时复用
+ */
+export interface TetrisState {
+  readonly grid: ReadonlyArray<number>;
+  readonly active: ActivePiece | null;
+  readonly next: PieceKind;
+  readonly awaitingFirstMove: boolean;
+  readonly over: boolean;
+  readonly overFrame: number;
+  readonly clearingLines: ReadonlyArray<number>;
+  readonly clearFrame: number;
+  readonly score: number;
+  readonly lines: number;
+  readonly lastOpts: { readonly speed: number; readonly level: number } | null;
+}
+
+/**
+ * 七种方块的四个旋转相位下的占格相对坐标
+ *
+ * 每个 PieceKind 是长度 4 的数组（旋转 0 / 90 / 180 / 270），每个相位是
+ * 长度 4 的相对坐标数组（一个方块固定 4 格）。坐标基准是方块包围盒左上角，
+ * x 向右 y 向下；具体数值参照 SRS 但因为我们不做踢墙（wallkick）所以不需
+ * 要带 kicks 表
+ */
+export const TETROMINOES: Readonly<Record<PieceKind, ReadonlyArray<ReadonlyArray<Pixel>>>> = {
+  // I：横躺 → 竖立 → 横躺（下半）→ 竖立（左半）。SRS 标准 4 行 4 列包围盒
+  I: [
+    [
+      [0, 1],
+      [1, 1],
+      [2, 1],
+      [3, 1],
+    ],
+    [
+      [2, 0],
+      [2, 1],
+      [2, 2],
+      [2, 3],
+    ],
+    [
+      [0, 2],
+      [1, 2],
+      [2, 2],
+      [3, 2],
+    ],
+    [
+      [1, 0],
+      [1, 1],
+      [1, 2],
+      [1, 3],
+    ],
+  ],
+  // O：2×2，四个相位相同
+  O: [
+    [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ],
+    [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ],
+    [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ],
+    [
+      [0, 0],
+      [1, 0],
+      [0, 1],
+      [1, 1],
+    ],
+  ],
+  // T：3×3 包围盒，中心十字加一只伸出的腿
+  T: [
+    [
+      [1, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ],
+    [
+      [1, 0],
+      [1, 1],
+      [2, 1],
+      [1, 2],
+    ],
+    [
+      [0, 1],
+      [1, 1],
+      [2, 1],
+      [1, 2],
+    ],
+    [
+      [1, 0],
+      [0, 1],
+      [1, 1],
+      [1, 2],
+    ],
+  ],
+  // S：之字（右上 - 左下）
+  S: [
+    [
+      [1, 0],
+      [2, 0],
+      [0, 1],
+      [1, 1],
+    ],
+    [
+      [1, 0],
+      [1, 1],
+      [2, 1],
+      [2, 2],
+    ],
+    [
+      [1, 1],
+      [2, 1],
+      [0, 2],
+      [1, 2],
+    ],
+    [
+      [0, 0],
+      [0, 1],
+      [1, 1],
+      [1, 2],
+    ],
+  ],
+  // Z：之字（左上 - 右下）
+  Z: [
+    [
+      [0, 0],
+      [1, 0],
+      [1, 1],
+      [2, 1],
+    ],
+    [
+      [2, 0],
+      [1, 1],
+      [2, 1],
+      [1, 2],
+    ],
+    [
+      [0, 1],
+      [1, 1],
+      [1, 2],
+      [2, 2],
+    ],
+    [
+      [1, 0],
+      [0, 1],
+      [1, 1],
+      [0, 2],
+    ],
+  ],
+  // J：勾子向左
+  J: [
+    [
+      [0, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ],
+    [
+      [1, 0],
+      [2, 0],
+      [1, 1],
+      [1, 2],
+    ],
+    [
+      [0, 1],
+      [1, 1],
+      [2, 1],
+      [2, 2],
+    ],
+    [
+      [1, 0],
+      [1, 1],
+      [0, 2],
+      [1, 2],
+    ],
+  ],
+  // L：勾子向右
+  L: [
+    [
+      [2, 0],
+      [0, 1],
+      [1, 1],
+      [2, 1],
+    ],
+    [
+      [1, 0],
+      [1, 1],
+      [1, 2],
+      [2, 2],
+    ],
+    [
+      [0, 1],
+      [1, 1],
+      [2, 1],
+      [0, 2],
+    ],
+    [
+      [0, 0],
+      [1, 0],
+      [1, 1],
+      [1, 2],
+    ],
+  ],
+};
+
+const ALL_KINDS: ReadonlyArray<PieceKind> = ['I', 'O', 'T', 'S', 'Z', 'J', 'L'];
+
+/** 用可播种 RNG 抽一种方块；确定性回放要求所有随机来源走 ctx.rng */
+export function pickKind(rng: () => number): PieceKind {
+  const idx = Math.floor(rng() * ALL_KINDS.length);
+  return ALL_KINDS[idx] ?? 'I';
+}
+
+/** 返回 (kind, rotation) 在场地上的绝对占格坐标，便于碰撞 / 渲染 */
+export function pieceCells(piece: ActivePiece): ReadonlyArray<Pixel> {
+  const shape = TETROMINOES[piece.kind][piece.rotation] ?? [];
+  return shape.map(([dx, dy]): Pixel => [piece.x + dx, piece.y + dy]);
+}
+
+/** 给定锚点 + 旋转，检查该形态在场地是否合法（无越界 / 不压到已锁砖块） */
+export function isValidPosition(
+  grid: ReadonlyArray<number>,
+  width: number,
+  height: number,
+  piece: ActivePiece
+): boolean {
+  for (const [x, y] of pieceCells(piece)) {
+    // 左右底部越界都返回 false；y<0 是"方块上半部分在屏外"的合法过渡态
+    // （spawn 时 y=-1 让方块从顶部滑入），既不算越界也无需检查 grid
+    if (x < 0 || x >= width || y >= height) return false;
+    if (y >= 0 && grid[y * width + x] === 1) return false;
+  }
+  return true;
+}

--- a/src/games/tetris/state.ts
+++ b/src/games/tetris/state.ts
@@ -30,8 +30,8 @@ export interface ActivePiece {
  * 放在右侧 SidePanel。我们的 SidePanel 暂不显示 next 预览（保持 PR
  * 体量），有需要再扩
  */
-export const FIELD_WIDTH = 10;
-export const FIELD_HEIGHT = 20;
+export const FIELD_WIDTH: number = 10;
+export const FIELD_HEIGHT: number = 20;
 
 /**
  * Tetris 完整 state

--- a/src/platform/browser/__tests__/input.test.ts
+++ b/src/platform/browser/__tests__/input.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { createInputBus } from '@/engine/input';
-import type { Button, InputBus } from '@/engine/types';
+import type { Button, ButtonAction, InputBus } from '@/engine/types';
 
 import { bindKeyboardInput, DEFAULT_KEY_MAP } from '../input';
 
@@ -31,7 +31,7 @@ describe('bindKeyboardInput', () => {
   });
 
   it('默认映射把方向键 / 空格 / 回车桥接到对应 Button', () => {
-    const log: Array<[Button, 'press' | 'release']> = [];
+    const log: Array<[Button, ButtonAction]> = [];
     input.subscribe((btn, action) => log.push([btn, action]));
     bindKeyboardInput(input, { target });
 
@@ -58,15 +58,91 @@ describe('bindKeyboardInput', () => {
     expect(fn).not.toHaveBeenCalled();
   });
 
-  it('长按重复 keydown 被 InputBus 去重，只通知一次', () => {
+  it('OS 重复 keydown (e.repeat=true) 被忽略 —— 重复触发由内部 timer 接管', () => {
     const fn = vi.fn();
     input.subscribe(fn);
     bindKeyboardInput(input, { target });
 
-    fireKey(target, 'keydown', 'ArrowUp');
-    fireKey(target, 'keydown', 'ArrowUp');
-    fireKey(target, 'keydown', 'ArrowUp');
+    fireKey(target, 'keydown', 'ArrowUp'); // 首次 → emit press
+    const repeat = new KeyboardEvent('keydown', {
+      key: 'ArrowUp',
+      cancelable: true,
+      bubbles: true,
+      repeat: true,
+    });
+    target.dispatchEvent(repeat);
+    target.dispatchEvent(repeat);
     expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('游戏键长按：press 后 delay ms 起每 interval ms emit "repeat"', () => {
+    vi.useFakeTimers();
+    const log: Array<[Button, string]> = [];
+    input.subscribe((btn, action) => log.push([btn, action]));
+    bindKeyboardInput(input, { target, repeatDelayMs: 200, repeatIntervalMs: 50 });
+
+    fireKey(target, 'keydown', 'ArrowRight');
+    expect(log).toEqual([['Right', 'press']]);
+    vi.advanceTimersByTime(199);
+    expect(log).toHaveLength(1);
+    // 延迟到期 → 第一次 repeat
+    vi.advanceTimersByTime(1);
+    expect(log[1]).toEqual(['Right', 'repeat']);
+    // 之后每 50ms 一次 repeat
+    vi.advanceTimersByTime(150);
+    expect(log).toHaveLength(5);
+    fireKey(target, 'keyup', 'ArrowRight');
+    vi.advanceTimersByTime(200);
+    expect(log[log.length - 1]).toEqual(['Right', 'release']);
+    vi.useRealTimers();
+  });
+
+  it('A 键（Rotate）也是游戏键 —— 长按生成 repeat 序列，让 Snake 用作快进', () => {
+    vi.useFakeTimers();
+    const log: Array<[Button, string]> = [];
+    input.subscribe((btn, action) => log.push([btn, action]));
+    bindKeyboardInput(input, { target, repeatDelayMs: 100, repeatIntervalMs: 50 });
+
+    fireKey(target, 'keydown', ' '); // 空格 → 'A'
+    expect(log).toEqual([['A', 'press']]);
+    vi.advanceTimersByTime(150); // 100 delay + 50 interval = 2 次 repeat
+    expect(log.filter(([, a]) => a === 'repeat')).toHaveLength(2);
+    vi.useRealTimers();
+  });
+
+  it('控制键（Start / Pause / Sound / Reset）长按不触发 repeat —— 没有"持续按下"语义', () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    input.subscribe(fn);
+    bindKeyboardInput(input, { target, repeatDelayMs: 100, repeatIntervalMs: 50 });
+
+    fireKey(target, 'keydown', 'Enter'); // 'Start'
+    fireKey(target, 'keydown', 'p'); // 'Pause'
+    fireKey(target, 'keydown', 'm'); // 'Sound'
+    fireKey(target, 'keydown', 'r'); // 'Reset'
+    expect(fn).toHaveBeenCalledTimes(4);
+    vi.advanceTimersByTime(500); // 即便等 500ms 也不会再触发
+    expect(fn).toHaveBeenCalledTimes(4);
+    vi.useRealTimers();
+  });
+
+  it('detach 时清掉所有未到期的 timer', () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    input.subscribe(fn);
+    const detach = bindKeyboardInput(input, {
+      target,
+      repeatDelayMs: 50,
+      repeatIntervalMs: 50,
+    });
+
+    fireKey(target, 'keydown', 'ArrowLeft');
+    vi.advanceTimersByTime(50);
+    expect(fn).toHaveBeenCalledTimes(2);
+    detach();
+    vi.advanceTimersByTime(500);
+    expect(fn).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 
   it('命中映射时默认会 preventDefault', () => {

--- a/src/platform/browser/input.ts
+++ b/src/platform/browser/input.ts
@@ -20,9 +20,39 @@ export const DEFAULT_KEY_MAP: Readonly<Record<string, Button>> = {
   x: 'B',
   Enter: 'Start',
   Shift: 'Select',
+  p: 'Pause',
   m: 'Sound',
   r: 'Reset',
 };
+
+/**
+ * 平台层生成 long-press repeat 的按键集合 —— "游戏键"。
+ *
+ * 这是 *平台层*（输入硬件抽象）的判断："这种按键的物理特性决定了长按
+ * 时玩家有持续触发的期望"。和具体哪款游戏无关：
+ * - 方向键 / A / B 是经典游戏键，长按物理上是"持续意图"
+ * - Start / Pause / Sound / Reset / Select 是控制键，长按没有"持续"语义
+ *   （按住 Reset 不应该重复重开局）
+ *
+ * 游戏在 onButton 内通过 ButtonAction='repeat' 决定要不要响应这次 repeat。
+ * 游戏不需要知道哪些键 repeat、不需要知道节奏，平台层做出合理默认即可
+ */
+const REPEAT_KEYS: ReadonlySet<Button> = new Set(['Up', 'Down', 'Left', 'Right', 'A', 'B']);
+
+/**
+ * 长按起始延迟（毫秒）—— 首次按下到开始 repeat 的间隔。
+ *
+ * 250ms 接近 OS 习惯的"短点按 vs 长按"分界。低于这个就分不清意图：玩家点
+ * 一下方向键打算"走一格 + 改向"，但延迟太短就被当成长按又走多格
+ */
+const REPEAT_DELAY_MS = 250;
+
+/**
+ * 长按重复触发间隔（毫秒）
+ *
+ * 100ms = 10 steps/s，对齐社区主流 Web 实现的体感
+ */
+const REPEAT_INTERVAL_MS = 100;
 
 export interface BindKeyboardOptions {
   /** 绑定目标；默认 window */
@@ -31,43 +61,85 @@ export interface BindKeyboardOptions {
   keyMap?: Readonly<Record<string, Button>>;
   /** 命中映射时是否阻止默认行为（如方向键滚动页面）；默认 true */
   preventDefault?: boolean;
+  /** 长按起始延迟（毫秒）；默认 250ms。区分"点按"与"长按"意图 */
+  repeatDelayMs?: number;
+  /** 长按重复触发间隔（毫秒）；默认 100ms */
+  repeatIntervalMs?: number;
 }
 
 /**
  * 把键盘事件桥接到 L3 InputBus
  *
  * 行为：
- * - keydown → inputBus.emit(btn, 'press')
- * - keyup   → inputBus.emit(btn, 'release')
+ * - 首次 keydown（e.repeat=false）→ inputBus.emit(btn, 'press')。若 btn 是
+ *   游戏键（方向键 / A / B），再调度 repeatDelayMs 后开始按 repeatIntervalMs
+ *   周期 emit 'repeat'，直到 keyup
+ * - OS 重复 keydown（e.repeat=true）→ 忽略（我们的 timer 接管节奏）
+ * - keyup → 清掉该键的 timer（若有）+ inputBus.emit(btn, 'release')
  * - 未命中映射的按键忽略，不吞事件
- * - 长按浏览器会重复发 keydown，InputBus.emit 已对重复 press 去重
  * - 带 Ctrl / Meta / Alt 修饰键的组合一律不处理，留给浏览器快捷键
  *   （Ctrl+R / Cmd+R 刷新、Cmd+W 关标签、DevTools 等）
  *
- * @returns 解绑函数，调用后移除事件监听
+ * @returns 解绑函数，调用后移除事件监听；解绑时也会清掉所有未到期的 timer
  */
 export function bindKeyboardInput(inputBus: InputBus, opts: BindKeyboardOptions = {}): Unsubscribe {
-  const { target = window, keyMap = DEFAULT_KEY_MAP, preventDefault = true } = opts;
+  const {
+    target = window,
+    keyMap = DEFAULT_KEY_MAP,
+    preventDefault = true,
+    repeatDelayMs = REPEAT_DELAY_MS,
+    repeatIntervalMs = REPEAT_INTERVAL_MS,
+  } = opts;
 
-  const onKey =
-    (action: 'press' | 'release') =>
-    (ev: Event): void => {
-      const e = ev as KeyboardEvent;
-      if (e.ctrlKey || e.metaKey || e.altKey) return;
-      const btn = keyMap[e.key];
-      if (!btn) return;
-      if (preventDefault) e.preventDefault();
-      inputBus.emit(btn, action);
-    };
+  // 每个正在长按的 button 对应一个 setTimeout 句柄（递归 self-reschedule）
+  const repeatTimers = new Map<Button, ReturnType<typeof setTimeout>>();
 
-  const down = onKey('press');
-  const up = onKey('release');
+  const scheduleRepeat = (btn: Button, delay: number): void => {
+    const id = setTimeout(() => {
+      inputBus.emit(btn, 'repeat');
+      scheduleRepeat(btn, repeatIntervalMs);
+    }, delay);
+    repeatTimers.set(btn, id);
+  };
 
-  target.addEventListener('keydown', down);
-  target.addEventListener('keyup', up);
+  const clearRepeat = (btn: Button): void => {
+    const id = repeatTimers.get(btn);
+    if (id !== undefined) {
+      clearTimeout(id);
+      repeatTimers.delete(btn);
+    }
+  };
+
+  const onDown = (ev: Event): void => {
+    const e = ev as KeyboardEvent;
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    const btn = keyMap[e.key];
+    if (!btn) return;
+    if (preventDefault) e.preventDefault();
+    if (e.repeat) return; // OS 重复 keydown 由我们的 timer 接管
+    inputBus.emit(btn, 'press');
+    if (REPEAT_KEYS.has(btn) && !repeatTimers.has(btn)) {
+      scheduleRepeat(btn, repeatDelayMs);
+    }
+  };
+
+  const onUp = (ev: Event): void => {
+    const e = ev as KeyboardEvent;
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    const btn = keyMap[e.key];
+    if (!btn) return;
+    if (preventDefault) e.preventDefault();
+    clearRepeat(btn);
+    inputBus.emit(btn, 'release');
+  };
+
+  target.addEventListener('keydown', onDown);
+  target.addEventListener('keyup', onUp);
 
   return () => {
-    target.removeEventListener('keydown', down);
-    target.removeEventListener('keyup', up);
+    for (const id of repeatTimers.values()) clearTimeout(id);
+    repeatTimers.clear();
+    target.removeEventListener('keydown', onDown);
+    target.removeEventListener('keyup', onUp);
   };
 }

--- a/src/platform/browser/sound.ts
+++ b/src/platform/browser/sound.ts
@@ -58,12 +58,15 @@ const PRESETS: Partial<Record<SoundEffect, Preset>> = {
 
 /**
  * Sample 切片时间表（秒）。对应 public/sounds/sfx.m4a 的内部布局：
- *   [0       , 0.1437)   move   —— 按键 click
+ *   [0       , 0.1437)   move   —— 按键 click（实际只播前 0.1s）
  *   [0.1437  , 1.2874)   over   —— 死亡嗡鸣
+ *
+ * move duration 0.1s 配合"新 click 触发时截断旧 click"机制（见 play 实现），
+ * 长按时听感是干脆的"嘀-嘀-嘀"而不是叠加糊在一起
  */
 const SAMPLE_URL = 'sounds/sfx.m4a';
 const SAMPLE_RANGES: Partial<Record<SoundEffect, { offset: number; duration: number }>> = {
-  move: { offset: 0, duration: 0.1437 },
+  move: { offset: 0, duration: 0.1 },
   over: { offset: 0.1437, duration: 1.1437 },
 };
 /**
@@ -105,6 +108,9 @@ export function createBrowserSound(): Sound {
   let masterGain: GainNode | null = null;
   let sampleBuffer: AudioBuffer | null = null;
   let sampleLoading = false;
+  // 每个 sample effect 当前在播的 BufferSource —— 新 click 触发时把同 effect
+  // 的旧 BufferSource 截断，避免长按时声音叠在一起糊
+  const activeSamples = new Map<SoundEffect, AudioBufferSourceNode>();
 
   const ensureCtx = (): AudioContext | null => {
     if (audioCtx) return audioCtx;
@@ -164,11 +170,27 @@ export function createBrowserSound(): Sound {
       if (range) {
         // buffer 还没就绪 / 加载失败 → 静默。不 fallback 合成（用户确认合成版完全不像）
         if (!sampleBuffer) return;
+        // 截断同 effect 的上一个 BufferSource（如果它还在播）。常见场景：长按
+        // 方向键时每 100ms 触发一次 move click，旧 click 还在播 → 直接砍掉让
+        // 新 click 接上，听感是干脆的"嘀-嘀-嘀"而不是糊在一起
+        const prev = activeSamples.get(effect);
+        if (prev) {
+          try {
+            prev.stop();
+          } catch {
+            // 已自然结束的 BufferSource 重复 stop 会抛 InvalidStateError，吞掉
+          }
+        }
         const src = ac.createBufferSource();
         src.buffer = sampleBuffer;
         const gainNode = ac.createGain();
         gainNode.gain.value = SAMPLE_GAIN;
         src.connect(gainNode).connect(out(ac));
+        // 自然结束时清登记表，让下次同 effect 触发不再尝试 stop 已结束的节点
+        src.onended = (): void => {
+          if (activeSamples.get(effect) === src) activeSamples.delete(effect);
+        };
+        activeSamples.set(effect, src);
         // when=0 表示立即；offset / duration 单位秒，对齐 sfx.m4a 内部布局
         src.start(0, range.offset, range.duration);
         return;

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -6,6 +6,7 @@
  */
 
 export type { AnyGame, Game, GameEnv, GameInitOptions, GamePreview, Pixel } from './types';
+export type { Button, ButtonAction } from '@/engine/types';
 export { toGameEnv } from './env';
 export { createRegistry } from './registry';
 export type { GameRegistry } from './registry';

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -92,6 +92,18 @@ export interface Game<S = unknown> {
   onButton?(env: GameEnv, state: S, btn: Button, action: ButtonAction): S;
   /** 判定游戏是否结束；App 据此决定是否暂停推进 / 回菜单 */
   isGameOver?(state: S): boolean;
+
+  /**
+   * 当前是否处于"游戏内动画"阶段（如 Snake 死亡爆炸、Tetris 消行闪烁）。
+   *
+   * App 据此把 ticker 切到固定的 ANIM_TICK_SPEED，让动画节奏不被 baseline
+   * tickSpeed 拖慢 —— 玩家选 speed=1 (慢慢玩) 时，消行 / 死亡动画也能用
+   * 固定的 ~50ms/帧 节奏播完，而不是动辄 1~2 秒卡顿
+   *
+   * 默认假定 isGameOver=true 时也算动画期，省一次实现：Snake 不必再实现
+   * 这个方法
+   */
+  isAnimating?(state: S): boolean;
 }
 
 /** 任意游戏的无类型视图，便于 App / Registry 等消费方统一持有 */

--- a/src/ui/Buttons/Buttons.tsx
+++ b/src/ui/Buttons/Buttons.tsx
@@ -1,17 +1,31 @@
-import { type PointerEvent as ReactPointerEvent, useCallback } from 'react';
+import { type PointerEvent as ReactPointerEvent, useCallback, useEffect, useRef } from 'react';
 
 import type { Button, ButtonAction } from '@/engine/types';
 import { BUTTON_LABELS, type ButtonLabels } from '@/ui/locale';
 
 import styles from './Buttons.module.css';
 
+/**
+ * 屏幕按钮长按节奏 —— 与 bindKeyboardInput 同套（参见对应注释）。
+ * 起始延迟 250ms 区分点按 / 长按，到期后每 100ms 发一次 'repeat'
+ */
+const REPEAT_DELAY_MS = 250;
+const REPEAT_INTERVAL_MS = 100;
+
+/**
+ * 参与 long-press repeat 的按键集合 —— 平台层对"游戏键"的判断（方向键 / A / B）。
+ * 与 bindKeyboardInput 内的 REPEAT_KEYS 保持一致；游戏在 onButton 内通过
+ * ButtonAction='repeat' 决定要不要响应
+ */
+const REPEAT_KEYS: ReadonlySet<Button> = new Set(['Up', 'Down', 'Left', 'Right', 'A', 'B']);
+
 export interface ButtonsProps {
   /**
-   * 按键交互回调，press / release 成对触发。
+   * 按键交互回调，press / repeat / release 三类。
    *
    * 实现上用 PointerEvent + setPointerCapture 保证按下后拖出按钮、
-   * 触屏滑出边界等场景都能可靠收到 release——这样 L3 InputBus 的
-   * "重复 press 去重 + release 必须配对" 语义才不会被 UI 破坏。
+   * 触屏滑出边界等场景都能可靠收到 release。游戏键长按时会在 press 后
+   * 起每 100ms 发一次 'repeat'，与键盘节奏一致
    */
   onInput?: (btn: Button, action: ButtonAction) => void;
   /** 按键外围的文字标签；不传用英文 */
@@ -25,11 +39,11 @@ export interface ButtonsProps {
  * （buttonTip 文字标签 + buttonDir 箭头），三者的相对位置由 CSS 绝对定位
  * 落到按钮外围，从而在 4 个按钮的中心围出一个十字形箭头簇。
  *
- * 顶部一行小按钮 START / SOUND / RESET 复刻真机的辅助键位（真机另有
- * ON/OFF 我们略掉 —— 网页关不掉 tab）。
+ * 顶部一行小按钮 START / PAUSE / SOUND / RESET 复刻真机的辅助键位。
  *
  * 按键到 InputBus 的映射：
  * - 顶部 START 小按钮 → 'Start'（兼任开/关键 = 真机的 ON/OFF）
+ * - 顶部 PAUSE       → 'Pause'
  * - 顶部 SOUND       → 'Sound'
  * - 顶部 RESET       → 'Reset'
  * - D-pad 4 个方向键 → 'Up' / 'Down' / 'Left' / 'Right'
@@ -39,26 +53,66 @@ export function Buttons({
   onInput,
   labels = BUTTON_LABELS['en-US'],
 }: ButtonsProps): React.ReactElement {
+  // 每个正在长按的方向键对应一个 setTimeout（递归 self-reschedule 模式）；
+  // pointer release / cancel 时按 btn 清掉。用 ref 持有保证跨渲染稳定，
+  // 不参与 React 重渲染依赖
+  const repeatTimersRef = useRef<Map<Button, ReturnType<typeof setTimeout>>>(new Map());
+
+  // 组件 unmount 时清掉所有未到期的 timer —— 防御性，正常 release/cancel
+  // 会自己清，但极端情况（用户切走 tab）能兜底
+  useEffect(() => {
+    const timers = repeatTimersRef.current;
+    return () => {
+      for (const id of timers.values()) clearTimeout(id);
+      timers.clear();
+    };
+  }, []);
+
+  const clearRepeat = useCallback((btn: Button) => {
+    const id = repeatTimersRef.current.get(btn);
+    if (id !== undefined) {
+      clearTimeout(id);
+      repeatTimersRef.current.delete(btn);
+    }
+  }, []);
+
   const makeHandlers = useCallback(
     (btn: Button) => ({
       onPointerDown: (e: ReactPointerEvent<HTMLButtonElement>): void => {
         e.currentTarget.setPointerCapture(e.pointerId);
         onInput?.(btn, 'press');
+        if (REPEAT_KEYS.has(btn) && !repeatTimersRef.current.has(btn) && onInput) {
+          // 递归 setTimeout：到期 emit 'repeat' 后 reschedule 下一次（每 100ms），
+          // 首次延迟 250ms。inline 在闭包里避免 useCallback self-reference
+          // 触发 react-hooks/immutability
+          const timers = repeatTimersRef.current;
+          const emit = onInput;
+          const schedule = (delay: number): void => {
+            const id = setTimeout(() => {
+              emit(btn, 'repeat');
+              schedule(REPEAT_INTERVAL_MS);
+            }, delay);
+            timers.set(btn, id);
+          };
+          schedule(REPEAT_DELAY_MS);
+        }
       },
       onPointerUp: (e: ReactPointerEvent<HTMLButtonElement>): void => {
         if (e.currentTarget.hasPointerCapture(e.pointerId)) {
           e.currentTarget.releasePointerCapture(e.pointerId);
         }
+        clearRepeat(btn);
         onInput?.(btn, 'release');
       },
       onPointerCancel: (e: ReactPointerEvent<HTMLButtonElement>): void => {
         if (e.currentTarget.hasPointerCapture(e.pointerId)) {
           e.currentTarget.releasePointerCapture(e.pointerId);
         }
+        clearRepeat(btn);
         onInput?.(btn, 'release');
       },
     }),
-    [onInput]
+    [onInput, clearRepeat]
   );
 
   return (
@@ -74,6 +128,15 @@ export function Buttons({
             {...makeHandlers('Start')}
           />
           <span className={styles.smallTip}>{labels.start}</span>
+        </div>
+        <div className={styles.smallButtonGroup}>
+          <button
+            type="button"
+            aria-label="Pause"
+            className={styles.smallButton}
+            {...makeHandlers('Pause')}
+          />
+          <span className={styles.smallTip}>{labels.pause}</span>
         </div>
         <div className={styles.smallButtonGroup}>
           <button

--- a/src/ui/Buttons/Buttons.tsx
+++ b/src/ui/Buttons/Buttons.tsx
@@ -58,6 +58,13 @@ export function Buttons({
   // 不参与 React 重渲染依赖
   const repeatTimersRef = useRef<Map<Button, ReturnType<typeof setTimeout>>>(new Map());
 
+  // 用 ref 持有最新 onInput 引用：递归 setTimeout 闭包捕获的是创建时的值，
+  // 如果 onInput prop 变化，旧闭包会调旧函数。通过 ref 间接访问始终拿到最新
+  const onInputRef = useRef(onInput);
+  useEffect(() => {
+    onInputRef.current = onInput;
+  }, [onInput]);
+
   // 组件 unmount 时清掉所有未到期的 timer —— 防御性，正常 release/cancel
   // 会自己清，但极端情况（用户切走 tab）能兜底
   useEffect(() => {
@@ -80,16 +87,12 @@ export function Buttons({
     (btn: Button) => ({
       onPointerDown: (e: ReactPointerEvent<HTMLButtonElement>): void => {
         e.currentTarget.setPointerCapture(e.pointerId);
-        onInput?.(btn, 'press');
-        if (REPEAT_KEYS.has(btn) && !repeatTimersRef.current.has(btn) && onInput) {
-          // 递归 setTimeout：到期 emit 'repeat' 后 reschedule 下一次（每 100ms），
-          // 首次延迟 250ms。inline 在闭包里避免 useCallback self-reference
-          // 触发 react-hooks/immutability
+        onInputRef.current?.(btn, 'press');
+        if (REPEAT_KEYS.has(btn) && !repeatTimersRef.current.has(btn)) {
           const timers = repeatTimersRef.current;
-          const emit = onInput;
           const schedule = (delay: number): void => {
             const id = setTimeout(() => {
-              emit(btn, 'repeat');
+              onInputRef.current?.(btn, 'repeat');
               schedule(REPEAT_INTERVAL_MS);
             }, delay);
             timers.set(btn, id);
@@ -102,17 +105,17 @@ export function Buttons({
           e.currentTarget.releasePointerCapture(e.pointerId);
         }
         clearRepeat(btn);
-        onInput?.(btn, 'release');
+        onInputRef.current?.(btn, 'release');
       },
       onPointerCancel: (e: ReactPointerEvent<HTMLButtonElement>): void => {
         if (e.currentTarget.hasPointerCapture(e.pointerId)) {
           e.currentTarget.releasePointerCapture(e.pointerId);
         }
         clearRepeat(btn);
-        onInput?.(btn, 'release');
+        onInputRef.current?.(btn, 'release');
       },
     }),
-    [onInput, clearRepeat]
+    [clearRepeat]
   );
 
   return (

--- a/src/ui/SidePanel/SidePanel.tsx
+++ b/src/ui/SidePanel/SidePanel.tsx
@@ -11,8 +11,6 @@ export interface SidePanelProps {
   hiScore?: number;
   level?: number;
   speed?: number;
-  /** 'select' 指示灯是否点亮（仅在选择态亮） */
-  selectMode?: boolean;
   /** 'pause' 指示灯是否点亮 */
   pauseMode?: boolean;
   /** 'sound' 指示灯是否点亮（反映 ctx.soundOn） */
@@ -32,7 +30,6 @@ export function SidePanel({
   hiScore = 0,
   level = 1,
   speed = 1,
-  selectMode = false,
   pauseMode = false,
   soundOn = false,
 }: SidePanelProps): React.ReactElement {
@@ -57,7 +54,6 @@ export function SidePanel({
       </div>
 
       <div className={styles.indicators}>
-        <p className={selectMode ? styles.indicatorOn : styles.indicatorOff}>SELECT</p>
         <p className={pauseMode ? styles.indicatorOn : styles.indicatorOff}>PAUSE</p>
         <p className={soundOn ? styles.indicatorOn : styles.indicatorOff}>SOUND</p>
       </div>

--- a/src/ui/locale/__tests__/locale.test.ts
+++ b/src/ui/locale/__tests__/locale.test.ts
@@ -21,7 +21,7 @@ describe('detectLocale', () => {
 });
 
 describe('BUTTON_LABELS', () => {
-  it('每个 locale 都包含完整 8 个按键标签（D-pad + Rotate + Start/Sound/Reset 小按钮）', () => {
+  it('每个 locale 都包含完整 9 个按键标签（D-pad + Rotate + Start/Pause/Sound/Reset 小按钮）', () => {
     for (const locale of Object.keys(BUTTON_LABELS) as (keyof typeof BUTTON_LABELS)[]) {
       const l = BUTTON_LABELS[locale];
       expect(l.up).toBeTruthy();
@@ -30,6 +30,7 @@ describe('BUTTON_LABELS', () => {
       expect(l.right).toBeTruthy();
       expect(l.rotate).toBeTruthy();
       expect(l.start).toBeTruthy();
+      expect(l.pause).toBeTruthy();
       expect(l.sound).toBeTruthy();
       expect(l.reset).toBeTruthy();
     }

--- a/src/ui/locale/index.ts
+++ b/src/ui/locale/index.ts
@@ -19,6 +19,7 @@ export interface ButtonLabels {
   readonly right: string;
   readonly rotate: string;
   readonly start: string;
+  readonly pause: string;
   readonly sound: string;
   readonly reset: string;
 }
@@ -31,6 +32,7 @@ export const BUTTON_LABELS: Readonly<Record<Locale, ButtonLabels>> = {
     right: '右',
     rotate: '旋转',
     start: '开/关',
+    pause: '暂停',
     sound: '声音',
     reset: '重置',
   },
@@ -41,6 +43,7 @@ export const BUTTON_LABELS: Readonly<Record<Locale, ButtonLabels>> = {
     right: 'Right',
     rotate: 'Rotate',
     start: 'On/Off',
+    pause: 'Pause',
     sound: 'Sound',
     reset: 'Reset',
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,8 +18,27 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html', 'lcov'],
-      exclude: ['**/*.config.*', '**/*.d.ts'],
+      // text: 终端摘要；html: 本地浏览看详情；lcov: 通用格式给外部服务；
+      // json-summary + json: PR 评论 action 需要的机器可读格式
+      reporter: ['text', 'html', 'lcov', 'json-summary', 'json'],
+      // 排除非源码：配置 / 类型声明 / 入口 / barrel files / 平台层启动文件
+      exclude: [
+        '**/*.config.*',
+        '**/*.d.ts',
+        'src/main.tsx',
+        'src/**/index.ts', // L1/L2/L3 各层的 barrel re-export，无实际逻辑
+        'src/**/__tests__/**',
+        'dist/**',
+      ],
+      // 覆盖率门槛：低于这些数值 vitest 会以非零码退出 → CI 失败 → 阻挡 PR
+      // 合并。取接入门槛时实际覆盖率向下取约 1% buffer，避免常规小改动卡
+      // PR；补完 sample 路径的 mock 测试后这几个数应该能整体上调
+      thresholds: {
+        lines: 88,
+        statements: 86,
+        functions: 85,
+        branches: 81,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

重做按键架构 + Tetris 完整可玩 + 体验打磨（暂停 / 动画 / 音效 / 覆盖率）。

### L3 引擎层 + 平台层

- `ButtonAction` 扩展为 `press / repeat / release` 三态
- 平台层（键盘 + 屏幕按钮）统一管理长按 repeat（250ms 延迟 + 100ms 间隔），替换旧的 App 层 BOOST_KEYS 提频方案
- 新增 `Pause` Button；音效截断旧 BufferSource 避免长按叠音

### L1 游戏层 · Snake

- **按键即走**：方向键 / A 键 press + repeat 立即推进一格 + skipNextTick 跳过下一自然 tick，松开恢复自然节奏
- 速度档位重调（speed=9 → 10 ticks/s）

### L1 游戏层 · Tetris（新增）

- 七种方块 SRS 坐标 + 碰撞检测 + 旋转 / 平移 / 软降
- 消行闪烁动画（`% 6 >= 3` 稀疏闪烁，3 帧亮 / 3 帧暗 ≈ 5Hz）
- 死亡动画（填屏 + 清屏，与 Snake 同套节奏）
- 完整测试：`gridFromAscii` 辅助构造任意棋盘，覆盖单/双/三/四消 + 砖块下落 + spawn + game over

### L4 UI 壳层 + App

- 移除 BOOST_KEYS / BOOST_FACTOR（加速下移到各游戏 onButton）
- `isAnimating` 动画态切速（消行闪烁 / 死亡动画用固定 30fps）
- Pause 暂停 + 暂停态拦截游戏键
- Reset playing 内重开当前局；Select 退回菜单
- Buttons 增加 Pause 按钮 + 屏幕按钮 long-press repeat
- 移除 SidePanel 的 SELECT 指示灯（无实际用途）

### CI

- `pnpm coverage` + vitest-coverage-report-action 贴 PR 覆盖率
- 覆盖率门槛：lines 88% / statements 86% / functions 85% / branches 81%

## Test plan

- [x] `pnpm test` 209 通过
- [x] 浏览器验证 Tetris 消行闪烁节奏（稀疏，约 2~3 次闪烁）
- [x] 浏览器验证 Snake 按键即走手感（按即动 + 松开恢复）
- [x] 浏览器验证 Pause 键暂停 / 恢复
- [x] CI 覆盖率 action 正常贴评论

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 新增完整实现的俄罗斯方块游戏
  * 新增暂停按钮和暂停模式控制
  * 优化游戏按键响应，支持按键长按重复触发
  * 增强贪吃蛇游戏的操作体验，支持按键立即移动

* **改进**
  * 改进音效播放时序（移动音效优化）
  * 优化暂停/恢复功能的处理逻辑

* **测试**
  * 新增俄罗斯方块完整测试套件
  * 扩展贪吃蛇和输入处理测试覆盖

* **其他**
  * 更新 CI 工作流，添加覆盖率报告功能

<!-- end of auto-generated comment: release notes by coderabbit.ai -->