### PR TITLE
feat: nextScreen 重构、AI 自动玩、训练回放与 Dashboard 改进

### DIFF
--- a/src/ai/dqn.ts
+++ b/src/ai/dqn.ts
@@ -171,6 +171,8 @@ export function createDQNAgent(config: DQNConfig): DQNAgent {
       });
     },
 
+    // TODO: 前向传播在 tidy 和 optimizer.minimize 内各算一次，计算量翻倍；
+    // 应合并为一次，在 minimize 回调内同时取 loss 值
     train(batch: SampledBatch): number {
       const batchSize = batch.actions.length;
 

--- a/src/ai/train.ts
+++ b/src/ai/train.ts
@@ -240,6 +240,11 @@ async function main(): Promise<void> {
     }
     // 先清空旧日志，防止 Dashboard 读到上轮训练的残留数据
     fs.writeFileSync(`${args.outDir}/train-log.jsonl`, '');
+    // 同步清理上一轮残留的回放文件，避免页面在子进程写出新数据之前先回放旧 episode
+    const replayPath = `${args.outDir}/latest-replay.json`;
+    const replayTmpPath = `${args.outDir}/latest-replay.tmp`;
+    if (fs.existsSync(replayPath)) fs.unlinkSync(replayPath);
+    if (fs.existsSync(replayTmpPath)) fs.unlinkSync(replayTmpPath);
 
     const { fileURLToPath, URL: NodeURL } = await import('node:url');
     const { createServer } = await import('vite');

--- a/src/ai/train.ts
+++ b/src/ai/train.ts
@@ -111,6 +111,11 @@ async function runTraining(args: TrainArgs): Promise<void> {
     fs.appendFileSync(logPath, JSON.stringify(data) + '\n');
   };
   fs.writeFileSync(logPath, '');
+  // 清理上一轮残留的回放文件，避免游戏机播放过期数据
+  const replayTmpPath = `${outDir}/latest-replay.tmp`;
+  const replayPath = `${outDir}/latest-replay.json`;
+  if (fs.existsSync(replayPath)) fs.unlinkSync(replayPath);
+  if (fs.existsSync(replayTmpPath)) fs.unlinkSync(replayTmpPath);
   writeLog({ totalEpisodes: episodes });
 
   const recentRewards: number[] = [];
@@ -125,10 +130,12 @@ async function runTraining(args: TrainArgs): Promise<void> {
     let rlState = env.reset(seed + ep);
     let episodeReward = 0;
     let steps = 0;
+    const actions: number[] = [];
 
     while (true) {
       const obs = env.encodeState(rlState);
       const actionIdx = agent.act(obs);
+      actions.push(actionIdx);
       const action = env.actionSpace[actionIdx]!;
 
       const result = env.step(rlState, action);
@@ -156,6 +163,11 @@ async function runTraining(args: TrainArgs): Promise<void> {
       if (result.done) break;
       rlState = result.state;
     }
+
+    // 同步原子写入：JSON 体很小（< 几 KB），耗时亚毫秒，不影响训练速度
+    const json = JSON.stringify({ ep: ep + 1, seed: seed + ep, actions });
+    fs.writeFileSync(replayTmpPath, json);
+    fs.renameSync(replayTmpPath, replayPath);
 
     recentRewards.push(episodeReward);
     recentLengths.push(steps);
@@ -207,6 +219,7 @@ async function runTraining(args: TrainArgs): Promise<void> {
   }
 
   await agent.save(outDir);
+  writeLog({ done: true });
   console.log(`[训练] 模型已保存到 ${outDir}/`);
   console.log(`[训练] 日志已写入 ${logPath}`);
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,6 +11,7 @@ import {
 import { createPersistentCounter } from '@/engine/counter';
 import type { Button, ButtonAction, Counter } from '@/engine/types';
 import { defaultGames } from '@/games';
+import type { SnakeState } from '@/games/snake/state';
 import { bindKeyboardInput, createBrowserContext } from '@/platform/browser';
 import { createHeadlessContext } from '@/platform/headless';
 import type { Game, GameEnv, GameRegistry } from '@/sdk';
@@ -48,12 +49,18 @@ const BOOT_TICK_SPEED = 60;
 const AI_ACTION_MAP: readonly Button[] = ['Up', 'Down', 'Left', 'Right'];
 
 /**
- * 延迟加载的 encodeSnakeObs 缓存；加载 AI agent 时同步填入，
- * ticker 回调里直接读取，避免每 tick 都 dynamic import
+ * 延迟加载的 AI 推理桥：加载 agent 时把编码函数和场地尺寸一并填入，
+ * ticker 回调直接读取，避免每 tick 都 dynamic import
  */
-const encodeSnakeObsRef: {
-  current: ((game: unknown, w: number, h: number) => Float32Array) | null;
-} = { current: null };
+interface AIBridge {
+  encode: (game: SnakeState, w: number, h: number) => Float32Array;
+  readonly width: number;
+  readonly height: number;
+}
+const aiBridgeRef: { current: AIBridge | null } = { current: null };
+
+/** 目前唯一支持 AI 自动玩的游戏 id */
+const AI_GAME_ID = 'snake';
 
 /**
  * 选关 demo 视口：在主屏中间留出图标（上 6 行）和编号（下 5 行）的空间。
@@ -352,12 +359,16 @@ export function App(): React.ReactElement {
   const aiAgentRef = useRef<{ act(obs: Float32Array): number; dispose(): void } | null>(null);
   const aiPlayingRef = useRef(state.aiPlaying);
   const gameStateRef = useRef(state.gameState);
+  const playingIdRef = useRef(state.playingId);
   useEffect(() => {
     aiPlayingRef.current = state.aiPlaying;
   }, [state.aiPlaying]);
   useEffect(() => {
     gameStateRef.current = state.gameState;
   }, [state.gameState]);
+  useEffect(() => {
+    playingIdRef.current = state.playingId;
+  }, [state.playingId]);
   const [aiLoading, setAiLoading] = useState(false);
 
   // 通电：把"启动旋律"和"切 mode 到 boot"封装成单一动作，让 ON/OFF 按键
@@ -385,23 +396,26 @@ export function App(): React.ReactElement {
     startAiModeRef.current = () => {
       if (aiAgentRef.current || aiLoadingRef.current) return;
       const gameId = currentGame(registry, menuRef.current)?.id;
-      if (gameId !== 'snake') return;
+      if (gameId !== AI_GAME_ID) return;
 
       setAiLoading(true);
       void (async () => {
         try {
-          const [{ loadInferenceAgent }, { encodeSnakeObs }] = await Promise.all([
-            import('@/ai/inference'),
-            import('@/games/snake/rl'),
-          ]);
-          encodeSnakeObsRef.current = encodeSnakeObs as (
-            game: unknown,
-            w: number,
-            h: number
-          ) => Float32Array;
-          const agent = await loadInferenceAgent('/models/snake-dqn/model.json', 10 * 20 * 3);
+          const inferenceModule = await import('@/ai/inference');
+          const rlModule = await import('@/games/snake/rl');
+          aiBridgeRef.current = {
+            encode: rlModule.encodeSnakeObs,
+            width: rlModule.SNAKE_RL_WIDTH,
+            height: rlModule.SNAKE_RL_HEIGHT,
+          };
+          const obsSize =
+            rlModule.SNAKE_RL_WIDTH * rlModule.SNAKE_RL_HEIGHT * rlModule.SNAKE_RL_CHANNELS;
+          const agent = await inferenceModule.loadInferenceAgent(
+            '/models/snake-dqn/model.json',
+            obsSize
+          );
           aiAgentRef.current = agent;
-          dispatch({ type: 'AI_ENTER', gameId: 'snake' });
+          dispatch({ type: 'AI_ENTER', gameId: AI_GAME_ID });
         } catch (e) {
           console.warn('[AI] 模型加载失败:', e);
         } finally {
@@ -512,18 +526,22 @@ export function App(): React.ReactElement {
       // AI 模式：每 tick 先注入 AI 选择的方向键，再推进游戏。
       // try-catch 防止推理异常阻断 TICK 导致游戏完全冻结
       const agent = aiAgentRef.current;
-      if (agent && aiPlayingRef.current && modeRef.current === 'playing') {
+      const bridge = aiBridgeRef.current;
+      if (
+        agent &&
+        bridge &&
+        aiPlayingRef.current &&
+        modeRef.current === 'playing' &&
+        playingIdRef.current === AI_GAME_ID
+      ) {
         try {
-          const gs = gameStateRef.current as {
-            readonly body: ReadonlyArray<readonly [number, number]>;
-          } | null;
+          // playingId === AI_GAME_ID 已保证 gameState 是 SnakeState
+          const gs = gameStateRef.current as SnakeState | null;
           if (gs?.body) {
-            const obs = encodeSnakeObsRef.current?.(gs, 10, 20);
-            if (obs) {
-              const idx = agent.act(obs);
-              const btn = AI_ACTION_MAP[idx];
-              if (btn) dispatch({ type: 'INPUT', button: btn, kind: 'press' });
-            }
+            const obs = bridge.encode(gs, bridge.width, bridge.height);
+            const idx = agent.act(obs);
+            const btn = AI_ACTION_MAP[idx];
+            if (btn) dispatch({ type: 'INPUT', button: btn, kind: 'press' });
           }
         } catch (e) {
           console.error('[AI] 推理异常:', e);
@@ -660,26 +678,37 @@ export function App(): React.ReactElement {
     if (score > hiCounter.value) hiCounter.set(score);
   }, [score, state.mode, hiCounter]);
 
-  // AI 模式下 game over 后自动重开（等死亡动画播完 ~1s）
-  useEffect(() => {
-    if (!state.aiPlaying || state.mode !== 'playing' || !state.playingId) return;
+  // 把 game over 判断抽成稳定 boolean —— 死亡动画里 gameState 会反复变化，
+  // 但这个 boolean 一旦 true 就稳定到下一局，避免 effect 反复清理重建 setTimeout
+  const aiGameOver = useMemo(() => {
+    if (!state.aiPlaying || state.mode !== 'playing' || !state.playingId) return false;
     const game = registry.get(state.playingId);
-    if (!game?.isGameOver?.(state.gameState)) return;
-    const timer = setTimeout(() => {
-      dispatch({ type: 'AI_ENTER', gameId: state.playingId! });
-    }, 1200);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [state.aiPlaying, state.mode, state.playingId, state.gameState, registry, env]);
+    return !!game?.isGameOver?.(state.gameState);
+  }, [state.aiPlaying, state.mode, state.playingId, state.gameState, registry]);
 
-  // 关机 / 退出 AI 时释放推理 agent
+  // AI 模式下 game over 后自动重开（等死亡动画播完 ~1.2s）
+  useEffect(() => {
+    if (!aiGameOver) return;
+    const timer = setTimeout(() => {
+      dispatch({ type: 'AI_ENTER', gameId: AI_GAME_ID });
+    }, 1200);
+    return () => clearTimeout(timer);
+  }, [aiGameOver]);
+
+  // 关机 / 退出 AI 时释放推理 agent。组件卸载也要兜底，避免 WebGL/张量资源泄漏
   useEffect(() => {
     if (!state.aiPlaying && aiAgentRef.current) {
       aiAgentRef.current.dispose();
       aiAgentRef.current = null;
-      encodeSnakeObsRef.current = null;
+      aiBridgeRef.current = null;
     }
+    return () => {
+      if (aiAgentRef.current) {
+        aiAgentRef.current.dispose();
+        aiAgentRef.current = null;
+        aiBridgeRef.current = null;
+      }
+    };
   }, [state.aiPlaying]);
 
   return (

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -44,6 +44,17 @@ import {
 /** 开机动画速度：约每秒 60 像素 */
 const BOOT_TICK_SPEED = 60;
 
+/** AI 动作索引 → 按键的映射（与训练时 SnakeRLEnv.actionSpace 顺序一致） */
+const AI_ACTION_MAP: readonly Button[] = ['Up', 'Down', 'Left', 'Right'];
+
+/**
+ * 延迟加载的 encodeSnakeObs 缓存；加载 AI agent 时同步填入，
+ * ticker 回调里直接读取，避免每 tick 都 dynamic import
+ */
+const encodeSnakeObsRef: {
+  current: ((game: unknown, w: number, h: number) => Float32Array) | null;
+} = { current: null };
+
 /**
  * 选关 demo 视口：在主屏中间留出图标（上 6 行）和编号（下 5 行）的空间。
  * demo 游戏在 10×DEMO_H 的小场地里跑，渲染时偏移 DEMO_Y 行画到主屏
@@ -82,6 +93,8 @@ interface AppState {
   readonly demoState: unknown;
   /** demo 专用 GameEnv（小屏幕），null = 非 select 态 */
   readonly demoEnv: GameEnv | null;
+  /** 是否由 AI 控制当前游戏 */
+  readonly aiPlaying: boolean;
 }
 
 /**
@@ -98,7 +111,9 @@ type Action =
   | { type: 'TICK' }
   | { type: 'INPUT'; button: Button; kind: ButtonAction }
   | { type: 'POWER_ON' }
-  | { type: 'POWER_OFF' };
+  | { type: 'POWER_OFF' }
+  | { type: 'AI_ENTER'; gameId: string }
+  | { type: 'AI_EXIT' };
 
 interface ReduceDeps {
   readonly registry: GameRegistry;
@@ -115,6 +130,7 @@ function initialAppState(): AppState {
     gameState: null,
     demoState: null,
     demoEnv: null,
+    aiPlaying: false,
   };
 }
 
@@ -155,6 +171,31 @@ function reduce(state: AppState, action: Action, deps: ReduceDeps): AppState {
   if (action.type === 'POWER_OFF') {
     if (state.mode === 'off') return state;
     return initialAppState();
+  }
+
+  if (action.type === 'AI_ENTER') {
+    const game = registry.get(action.gameId);
+    if (!isPlayable(game)) return state;
+    return {
+      ...state,
+      mode: 'playing',
+      playingId: action.gameId,
+      gameState: game.init(env, { speed: state.menu.speed, level: state.menu.level }),
+      aiPlaying: true,
+    };
+  }
+
+  if (action.type === 'AI_EXIT') {
+    const de = createDemoEnv();
+    return {
+      ...state,
+      mode: 'select',
+      playingId: null,
+      gameState: null,
+      aiPlaying: false,
+      demoEnv: de,
+      demoState: initDemo(registry, state.menu, de),
+    };
   }
 
   if (action.type === 'TICK') {
@@ -252,6 +293,7 @@ function reduce(state: AppState, action: Action, deps: ReduceDeps): AppState {
         mode: 'select',
         playingId: null,
         gameState: null,
+        aiPlaying: false,
         demoEnv: de,
         demoState: initDemo(registry, state.menu, de),
       };
@@ -306,6 +348,18 @@ export function App(): React.ReactElement {
     modeRef.current = state.mode;
   }, [state.mode]);
 
+  // AI 推理相关 refs —— 存在 ref 里避免触发渲染
+  const aiAgentRef = useRef<{ act(obs: Float32Array): number; dispose(): void } | null>(null);
+  const aiPlayingRef = useRef(state.aiPlaying);
+  const gameStateRef = useRef(state.gameState);
+  useEffect(() => {
+    aiPlayingRef.current = state.aiPlaying;
+  }, [state.aiPlaying]);
+  useEffect(() => {
+    gameStateRef.current = state.gameState;
+  }, [state.gameState]);
+  const [aiLoading, setAiLoading] = useState(false);
+
   // 通电：把"启动旋律"和"切 mode 到 boot"封装成单一动作，让 ON/OFF 按键
   // 触发和 mount 时探测 autoplay 自动触发走同一通路。playMelody 必须在
   // user gesture 同步调用栈内才能被浏览器允许 resume AudioContext
@@ -314,6 +368,48 @@ export function App(): React.ReactElement {
     melodyCancelRef.current = ctx.sound.playMelody(BOOT_MELODY);
     dispatch({ type: 'POWER_ON' });
   }, [ctx.sound]);
+
+  // 加载 AI 模型并进入 AI 自动玩模式；通过 ref 暴露给 input subscriber，
+  // 避免 subscriber effect 因 menu/aiLoading 变化而频繁重建
+  const menuRef = useRef(state.menu);
+  const aiLoadingRef = useRef(aiLoading);
+  useEffect(() => {
+    menuRef.current = state.menu;
+  }, [state.menu]);
+  useEffect(() => {
+    aiLoadingRef.current = aiLoading;
+  }, [aiLoading]);
+
+  const startAiModeRef = useRef<() => void>(() => undefined);
+  useEffect(() => {
+    startAiModeRef.current = () => {
+      if (aiAgentRef.current || aiLoadingRef.current) return;
+      const gameId = currentGame(registry, menuRef.current)?.id;
+      if (gameId !== 'snake') return;
+
+      setAiLoading(true);
+      void (async () => {
+        try {
+          const [{ loadInferenceAgent }, { encodeSnakeObs }] = await Promise.all([
+            import('@/ai/inference'),
+            import('@/games/snake/rl'),
+          ]);
+          encodeSnakeObsRef.current = encodeSnakeObs as (
+            game: unknown,
+            w: number,
+            h: number
+          ) => Float32Array;
+          const agent = await loadInferenceAgent('/models/snake-dqn/model.json', 10 * 20 * 3);
+          aiAgentRef.current = agent;
+          dispatch({ type: 'AI_ENTER', gameId: 'snake' });
+        } catch (e) {
+          console.warn('[AI] 模型加载失败:', e);
+        } finally {
+          setAiLoading(false);
+        }
+      })();
+    };
+  });
 
   useEffect(() => {
     const unbind = bindKeyboardInput(ctx.input);
@@ -354,6 +450,12 @@ export function App(): React.ReactElement {
 
       // 关机状态：除上面 Start 已处理外，其它按键一律无响应
       if (modeRef.current === 'off') return;
+
+      // 选关模式按 B：加载模型 → AI 自动玩
+      if (kind === 'press' && button === 'B' && modeRef.current === 'select') {
+        startAiModeRef.current();
+        return;
+      }
 
       // 暂停态拦截游戏键 —— 不让 onButton 改 game state。Reset 已在上面先放行 +
       // 清了 pause，到这里 ctx.pause.value 已经是 false 不会被拦
@@ -407,6 +509,26 @@ export function App(): React.ReactElement {
 
   useEffect(() => {
     ctx.ticker.start(() => {
+      // AI 模式：每 tick 先注入 AI 选择的方向键，再推进游戏。
+      // try-catch 防止推理异常阻断 TICK 导致游戏完全冻结
+      const agent = aiAgentRef.current;
+      if (agent && aiPlayingRef.current && modeRef.current === 'playing') {
+        try {
+          const gs = gameStateRef.current as {
+            readonly body: ReadonlyArray<readonly [number, number]>;
+          } | null;
+          if (gs?.body) {
+            const obs = encodeSnakeObsRef.current?.(gs, 10, 20);
+            if (obs) {
+              const idx = agent.act(obs);
+              const btn = AI_ACTION_MAP[idx];
+              if (btn) dispatch({ type: 'INPUT', button: btn, kind: 'press' });
+            }
+          }
+        } catch (e) {
+          console.error('[AI] 推理异常:', e);
+        }
+      }
       dispatch({ type: 'TICK' });
     });
     return () => {
@@ -538,6 +660,28 @@ export function App(): React.ReactElement {
     if (score > hiCounter.value) hiCounter.set(score);
   }, [score, state.mode, hiCounter]);
 
+  // AI 模式下 game over 后自动重开（等死亡动画播完 ~1s）
+  useEffect(() => {
+    if (!state.aiPlaying || state.mode !== 'playing' || !state.playingId) return;
+    const game = registry.get(state.playingId);
+    if (!game?.isGameOver?.(state.gameState)) return;
+    const timer = setTimeout(() => {
+      dispatch({ type: 'AI_ENTER', gameId: state.playingId! });
+    }, 1200);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [state.aiPlaying, state.mode, state.playingId, state.gameState, registry, env]);
+
+  // 关机 / 退出 AI 时释放推理 agent
+  useEffect(() => {
+    if (!state.aiPlaying && aiAgentRef.current) {
+      aiAgentRef.current.dispose();
+      aiAgentRef.current = null;
+      encodeSnakeObsRef.current = null;
+    }
+  }, [state.aiPlaying]);
+
   return (
     <div className={styles.page}>
       <Device
@@ -547,15 +691,12 @@ export function App(): React.ReactElement {
             power={state.mode !== 'off'}
             score={score}
             hiScore={hiScore}
-            nextPreview={
-              state.mode === 'playing' && state.playingId
-                ? (registry.get(state.playingId)?.getNextPreview?.(state.gameState) ?? null)
-                : null
-            }
+            nextScreen={ctx.nextScreen}
             speed={state.menu.speed}
             level={state.menu.level}
             pauseMode={paused}
             soundOn={soundOn}
+            aiMode={state.aiPlaying}
           />
         }
         buttons={

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -162,6 +162,8 @@ export interface Storage {
  */
 export interface HardwareContext {
   screen: Screen;
+  /** 4×2 预览屏：游戏在 render 里直接画下一块，SidePanel 订阅渲染 */
+  nextScreen: Screen;
   ticker: Ticker;
   input: InputBus;
   sound: Sound;

--- a/src/games/snake/__tests__/rl.test.ts
+++ b/src/games/snake/__tests__/rl.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { createSnakeRLEnv } from '../rl';
+import { createSnakeRLEnv, encodeSnakeObs } from '../rl';
+import type { SnakeState } from '../state';
 
 describe('SnakeRLEnv', () => {
   const env = createSnakeRLEnv({ width: 10, height: 10, seed: 123 });
@@ -86,5 +87,61 @@ describe('SnakeRLEnv', () => {
       if (result.done) break;
     }
     expect(lastReward).toBe(-1.0);
+  });
+
+  describe('入口 fail-fast 校验', () => {
+    it('非法 width 抛错', () => {
+      expect(() => createSnakeRLEnv({ width: 0, height: 10 })).toThrow(/非法尺寸/);
+      expect(() => createSnakeRLEnv({ width: -5, height: 10 })).toThrow(/非法尺寸/);
+      expect(() => createSnakeRLEnv({ width: 1.5, height: 10 })).toThrow(/非法尺寸/);
+    });
+
+    it('非法 height 抛错', () => {
+      expect(() => createSnakeRLEnv({ width: 10, height: 0 })).toThrow(/非法尺寸/);
+    });
+
+    it('非法 maxIdleSteps 抛错', () => {
+      expect(() => createSnakeRLEnv({ maxIdleSteps: 0 })).toThrow(/非法 maxIdleSteps/);
+      expect(() => createSnakeRLEnv({ maxIdleSteps: -1 })).toThrow(/非法 maxIdleSteps/);
+    });
+  });
+
+  describe('encodeSnakeObs 越界校验', () => {
+    const fakeState = (overrides: Partial<SnakeState>): SnakeState =>
+      ({
+        body: [],
+        food: null,
+        ...overrides,
+      }) as SnakeState;
+
+    it('width/height 非法抛错', () => {
+      expect(() => encodeSnakeObs(fakeState({}), 0, 10)).toThrow(/非法尺寸/);
+      expect(() => encodeSnakeObs(fakeState({}), 10, 1.5)).toThrow(/非法尺寸/);
+    });
+
+    it('蛇头越界抛错', () => {
+      expect(() => encodeSnakeObs(fakeState({ body: [[100, 0]] }), 10, 10)).toThrow(/head 越界/);
+    });
+
+    it('蛇身越界抛错（错误信息包含索引）', () => {
+      expect(() =>
+        encodeSnakeObs(
+          fakeState({
+            body: [
+              [0, 0],
+              [-1, 0],
+            ],
+          }),
+          10,
+          10
+        )
+      ).toThrow(/body\[1\] 越界/);
+    });
+
+    it('食物越界抛错', () => {
+      expect(() => encodeSnakeObs(fakeState({ body: [[0, 0]], food: [0, 999] }), 10, 10)).toThrow(
+        /food 越界/
+      );
+    });
   });
 });

--- a/src/games/snake/rl.ts
+++ b/src/games/snake/rl.ts
@@ -51,8 +51,15 @@ export interface SnakeRLEnvOptions {
 export function createSnakeRLEnv(opts: SnakeRLEnvOptions = {}): RLEnv<SnakeRLState, SnakeAction> {
   const width = opts.width ?? SNAKE_RL_WIDTH;
   const height = opts.height ?? SNAKE_RL_HEIGHT;
+  // 入口 fail-fast：非法 width/height 不延后到 reset/encodeState 才报
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
+    throw new Error(`createSnakeRLEnv: 非法尺寸 width=${width}, height=${height}`);
+  }
   const baseSeed = opts.seed ?? DEFAULT_SEED;
   const maxIdle = opts.maxIdleSteps ?? width * height;
+  if (!Number.isInteger(maxIdle) || maxIdle <= 0) {
+    throw new Error(`createSnakeRLEnv: 非法 maxIdleSteps=${maxIdle}`);
+  }
 
   return {
     actionSpace: ACTION_SPACE,
@@ -134,11 +141,22 @@ export function encodeSnakeObs(game: SnakeState, width: number, height: number):
   const obs = new Float32Array(width * height * SNAKE_RL_CHANNELS);
   /**
    * 越界 = 上游 state 与 width/height 配置不一致的 bug，直接抛错暴露。
-   * 上层 ticker / 训练循环已有 try-catch，不会因此把整个进程搞挂
+   * 上层 ticker / 训练循环已有 try-catch，不会因此把整个进程搞挂。
+   *
+   * label 用字面量联合而非模板字符串，避免训练热路径每次循环都分配新字符串；
+   * 仅在罕见的越界分支才拼接索引信息
    */
-  const writePixel = (offset: number, x: number, y: number, label: string): void => {
+  type PixelLabel = 'head' | 'body' | 'food';
+  const writePixel = (
+    offset: number,
+    x: number,
+    y: number,
+    label: PixelLabel,
+    bodyIndex?: number
+  ): void => {
     if (x < 0 || x >= width || y < 0 || y >= height) {
-      throw new Error(`encodeSnakeObs: ${label} 越界 (${x}, ${y}) vs ${width}×${height}`);
+      const where = label === 'body' ? `body[${bodyIndex ?? -1}]` : label;
+      throw new Error(`encodeSnakeObs: ${where} 越界 (${x}, ${y}) vs ${width}×${height}`);
     }
     obs[offset + y * width + x] = 1;
   };
@@ -149,7 +167,7 @@ export function encodeSnakeObs(game: SnakeState, width: number, height: number):
   const ch1 = width * height;
   for (let i = 1; i < game.body.length; i++) {
     const seg = game.body[i];
-    if (seg) writePixel(ch1, seg[0], seg[1], `body[${i}]`);
+    if (seg) writePixel(ch1, seg[0], seg[1], 'body', i);
   }
 
   if (game.food) writePixel(width * height * 2, game.food[0], game.food[1], 'food');

--- a/src/games/snake/rl.ts
+++ b/src/games/snake/rl.ts
@@ -25,8 +25,11 @@ import { init, onButton, step } from './logic';
 import type { SnakeState } from './state';
 
 const DEFAULT_SEED = 42;
-const DEFAULT_WIDTH = 10;
-const DEFAULT_HEIGHT = 20;
+/** 训练 / 推理共用的 Snake RL 场地尺寸；模型按此尺寸训练 */
+export const SNAKE_RL_WIDTH = 10;
+export const SNAKE_RL_HEIGHT = 20;
+/** 观测通道数：蛇头 / 蛇身 / 食物 */
+export const SNAKE_RL_CHANNELS = 3;
 
 /** 动作空间：四个方向键 */
 const ACTION_SPACE = ['Up', 'Down', 'Left', 'Right'] as const;
@@ -46,15 +49,14 @@ export interface SnakeRLEnvOptions {
 }
 
 export function createSnakeRLEnv(opts: SnakeRLEnvOptions = {}): RLEnv<SnakeRLState, SnakeAction> {
-  const width = opts.width ?? DEFAULT_WIDTH;
-  const height = opts.height ?? DEFAULT_HEIGHT;
+  const width = opts.width ?? SNAKE_RL_WIDTH;
+  const height = opts.height ?? SNAKE_RL_HEIGHT;
   const baseSeed = opts.seed ?? DEFAULT_SEED;
   const maxIdle = opts.maxIdleSteps ?? width * height;
-  const channels = 3;
 
   return {
     actionSpace: ACTION_SPACE,
-    observationShape: [width, height, channels],
+    observationShape: [width, height, SNAKE_RL_CHANNELS],
 
     reset(seed?: number): SnakeRLState {
       const ctx = createHeadlessContext({ seed: seed ?? baseSeed, width, height });
@@ -126,29 +128,31 @@ export interface SnakeRLState {
  * 通道 0：蛇头 / 通道 1：蛇身 / 通道 2：食物
  */
 export function encodeSnakeObs(game: SnakeState, width: number, height: number): Float32Array {
-  const channels = 3;
-  const obs = new Float32Array(width * height * channels);
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width <= 0 || height <= 0) {
+    throw new Error(`encodeSnakeObs: 非法尺寸 width=${width}, height=${height}`);
+  }
+  const obs = new Float32Array(width * height * SNAKE_RL_CHANNELS);
+  /**
+   * 越界 = 上游 state 与 width/height 配置不一致的 bug，直接抛错暴露。
+   * 上层 ticker / 训练循环已有 try-catch，不会因此把整个进程搞挂
+   */
+  const writePixel = (offset: number, x: number, y: number, label: string): void => {
+    if (x < 0 || x >= width || y < 0 || y >= height) {
+      throw new Error(`encodeSnakeObs: ${label} 越界 (${x}, ${y}) vs ${width}×${height}`);
+    }
+    obs[offset + y * width + x] = 1;
+  };
 
   const head = game.body[0];
-  if (head) {
-    const [hx, hy] = head;
-    obs[hy * width + hx] = 1;
-  }
+  if (head) writePixel(0, head[0], head[1], 'head');
 
   const ch1 = width * height;
   for (let i = 1; i < game.body.length; i++) {
     const seg = game.body[i];
-    if (seg) {
-      const [sx, sy] = seg;
-      obs[ch1 + sy * width + sx] = 1;
-    }
+    if (seg) writePixel(ch1, seg[0], seg[1], `body[${i}]`);
   }
 
-  const ch2 = width * height * 2;
-  if (game.food) {
-    const [fx, fy] = game.food;
-    obs[ch2 + fy * width + fx] = 1;
-  }
+  if (game.food) writePixel(width * height * 2, game.food[0], game.food[1], 'food');
 
   return obs;
 }

--- a/src/games/snake/rl.ts
+++ b/src/games/snake/rl.ts
@@ -101,35 +101,7 @@ export function createSnakeRLEnv(opts: SnakeRLEnvOptions = {}): RLEnv<SnakeRLSta
     },
 
     encodeState(rlState: SnakeRLState): Float32Array {
-      const size = width * height * channels;
-      const obs = new Float32Array(size);
-      const { game } = rlState;
-
-      // 通道 0：蛇头
-      const head = game.body[0];
-      if (head) {
-        const [hx, hy] = head;
-        obs[hy * width + hx] = 1;
-      }
-
-      // 通道 1：蛇身（不含头）
-      const ch1Offset = width * height;
-      for (let i = 1; i < game.body.length; i++) {
-        const seg = game.body[i];
-        if (seg) {
-          const [sx, sy] = seg;
-          obs[ch1Offset + sy * width + sx] = 1;
-        }
-      }
-
-      // 通道 2：食物
-      const ch2Offset = width * height * 2;
-      if (game.food) {
-        const [fx, fy] = game.food;
-        obs[ch2Offset + fy * width + fx] = 1;
-      }
-
-      return obs;
+      return encodeSnakeObs(rlState.game, width, height);
     },
   };
 }
@@ -145,4 +117,38 @@ export interface SnakeRLState {
   readonly env: ReturnType<typeof toGameEnv>;
   readonly score: number;
   readonly idleSteps: number;
+}
+
+/**
+ * 将 SnakeState 编码为 3 通道二值观测向量（与训练时一致）
+ *
+ * 独立函数，供浏览器推理时直接调用（不需要完整 RLEnv）。
+ * 通道 0：蛇头 / 通道 1：蛇身 / 通道 2：食物
+ */
+export function encodeSnakeObs(game: SnakeState, width: number, height: number): Float32Array {
+  const channels = 3;
+  const obs = new Float32Array(width * height * channels);
+
+  const head = game.body[0];
+  if (head) {
+    const [hx, hy] = head;
+    obs[hy * width + hx] = 1;
+  }
+
+  const ch1 = width * height;
+  for (let i = 1; i < game.body.length; i++) {
+    const seg = game.body[i];
+    if (seg) {
+      const [sx, sy] = seg;
+      obs[ch1 + sy * width + sx] = 1;
+    }
+  }
+
+  const ch2 = width * height * 2;
+  if (game.food) {
+    const [fx, fy] = game.food;
+    obs[ch2 + fy * width + fx] = 1;
+  }
+
+  return obs;
 }

--- a/src/games/tetris/index.ts
+++ b/src/games/tetris/index.ts
@@ -1,4 +1,4 @@
-import type { Game, GameEnv, Pixel } from '@/sdk';
+import type { Game, GameEnv } from '@/sdk';
 
 import { init, isAnimating, isGameOver, onButton, render, step } from './logic';
 import { tetrisPreview } from './preview';
@@ -131,14 +131,5 @@ export const tetris: Game<TetrisState> = {
       }
     }
     return step(env, state);
-  },
-
-  getNextPreview(state: TetrisState): ReadonlyArray<Pixel> | null {
-    if (state.over) return null;
-    const shape = TETROMINOES[state.next]?.[0];
-    if (!shape) return null;
-    // 归一化到 y=0 起始，适配 SidePanel 固定 4×2 迷你网格
-    const minY = Math.min(...shape.map(([, y]) => y));
-    return shape.map(([x, y]): Pixel => [x, y - minY]);
   },
 };

--- a/src/games/tetris/logic.ts
+++ b/src/games/tetris/logic.ts
@@ -230,13 +230,14 @@ export function render(env: GameEnv, state: TetrisState): void {
       for (const [x, y] of pieceCells(state.active)) screen.setPixel(x, y, true);
     }
 
-    // 预览屏：画下一块方块（归一化到 y=0）
+    // 预览屏：画下一块方块（XY 都归一化到 0，避免负坐标越界）
     const { nextScreen } = env;
     nextScreen.clear();
     const nextShape = TETROMINOES[state.next]?.[0];
     if (nextShape) {
+      const minX = Math.min(...nextShape.map(([sx]) => sx));
       const minY = Math.min(...nextShape.map(([, sy]) => sy));
-      for (const [sx, sy] of nextShape) nextScreen.setPixel(sx, sy - minY, true);
+      for (const [sx, sy] of nextShape) nextScreen.setPixel(sx - minX, sy - minY, true);
     }
     return;
   }

--- a/src/games/tetris/logic.ts
+++ b/src/games/tetris/logic.ts
@@ -229,8 +229,20 @@ export function render(env: GameEnv, state: TetrisState): void {
     if (state.active) {
       for (const [x, y] of pieceCells(state.active)) screen.setPixel(x, y, true);
     }
+
+    // 预览屏：画下一块方块（归一化到 y=0）
+    const { nextScreen } = env;
+    nextScreen.clear();
+    const nextShape = TETROMINOES[state.next]?.[0];
+    if (nextShape) {
+      const minY = Math.min(...nextShape.map(([, sy]) => sy));
+      for (const [sx, sy] of nextShape) nextScreen.setPixel(sx, sy - minY, true);
+    }
     return;
   }
+
+  // 死亡后清空预览屏
+  env.nextScreen.clear();
 
   // 死亡动画：填屏（自底向上）→ 清屏（自顶向下），各 h 帧
   if (state.overFrame < h) {

--- a/src/platform/browser/context.ts
+++ b/src/platform/browser/context.ts
@@ -52,6 +52,7 @@ export function createBrowserContext(opts: BrowserContextOptions): HardwareConte
 
   return {
     screen: createScreen(width, height),
+    nextScreen: createScreen(4, 2),
     ticker,
     input: createInputBus(),
     sound,

--- a/src/platform/browser/input.ts
+++ b/src/platform/browser/input.ts
@@ -113,7 +113,7 @@ export function bindKeyboardInput(inputBus: InputBus, opts: BindKeyboardOptions 
   const onDown = (ev: Event): void => {
     const e = ev as KeyboardEvent;
     if (e.ctrlKey || e.metaKey || e.altKey) return;
-    const btn = keyMap[e.key];
+    const btn = keyMap[e.key] ?? keyMap[e.key.toLowerCase()];
     if (!btn) return;
     if (preventDefault) e.preventDefault();
     if (e.repeat) return; // OS 重复 keydown 由我们的 timer 接管
@@ -126,7 +126,7 @@ export function bindKeyboardInput(inputBus: InputBus, opts: BindKeyboardOptions 
   const onUp = (ev: Event): void => {
     const e = ev as KeyboardEvent;
     if (e.ctrlKey || e.metaKey || e.altKey) return;
-    const btn = keyMap[e.key];
+    const btn = keyMap[e.key] ?? keyMap[e.key.toLowerCase()];
     if (!btn) return;
     if (preventDefault) e.preventDefault();
     clearRepeat(btn);

--- a/src/platform/headless/context.ts
+++ b/src/platform/headless/context.ts
@@ -40,6 +40,7 @@ export function createHeadlessContext(opts: HeadlessContextOptions): HardwareCon
 
   return {
     screen: createScreen(width, height),
+    nextScreen: createScreen(4, 2),
     ticker,
     input: createInputBus(),
     sound: createNullSound(),

--- a/src/sdk/env.ts
+++ b/src/sdk/env.ts
@@ -12,6 +12,7 @@ import type { GameEnv } from './types';
 export function toGameEnv(ctx: HardwareContext): GameEnv {
   return {
     screen: ctx.screen,
+    nextScreen: ctx.nextScreen,
     input: ctx.input,
     sound: ctx.sound,
     rng: ctx.rng,

--- a/src/sdk/types.ts
+++ b/src/sdk/types.ts
@@ -32,6 +32,8 @@ export type GamePreview = ReadonlyArray<Pixel>;
  */
 export interface GameEnv {
   readonly screen: Screen;
+  /** 4×2 预览屏：游戏在 render 里画下一块，UI 订阅变化自动渲染 */
+  readonly nextScreen: Screen;
   readonly input: InputBus;
   readonly sound: Sound;
   readonly rng: () => number;
@@ -104,17 +106,6 @@ export interface Game<S = unknown> {
    * 这个方法
    */
   isAnimating?(state: S): boolean;
-
-  /**
-   * 返回"下一块"预览的像素坐标（相对于 4×4 包围盒左上角）。
-   *
-   * SidePanel 据此在 HI-SCORE 下方画迷你方块预览。不实现则不显示。
-   * 目前只有 Tetris 需要（Snake 没有"下一块"概念）
-   *
-   * TODO: 仅 Tetris 使用，考虑拆为独立接口（如 WithNextPreview<S>），
-   * 避免 Game 接口膨胀——等第三款游戏确认需求后再决定
-   */
-  getNextPreview?(state: S): ReadonlyArray<Pixel> | null;
 
   /**
    * 选关界面自动演示：构造 demo 用初始态。

--- a/src/training/Dashboard.module.css
+++ b/src/training/Dashboard.module.css
@@ -90,6 +90,48 @@
   color: #888;
   font-weight: 500;
   margin: 0 0 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.helpIcon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid #555;
+  font-size: 9px;
+  color: #888;
+  cursor: help;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.helpIcon::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: 0;
+  top: calc(100% + 6px);
+  background: #1e1e2e;
+  color: #ccc;
+  font-size: 11px;
+  font-weight: 400;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid #333;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 10;
+}
+
+.helpIcon:hover::after {
+  opacity: 1;
 }
 
 .chart {

--- a/src/training/Dashboard.tsx
+++ b/src/training/Dashboard.tsx
@@ -84,6 +84,19 @@ function useChart(): {
   return { chartRef, bindRef };
 }
 
+/* ---------- 图表标题 + 帮助提示 ---------- */
+
+function ChartTitle({ text, tip }: { text: string; tip: string }): React.ReactElement {
+  return (
+    <h3 className={styles.chartTitle}>
+      {text}
+      <span className={styles.helpIcon} data-tip={tip}>
+        ?
+      </span>
+    </h3>
+  );
+}
+
 /* ---------- 子图表组件 ---------- */
 
 function RewardChart({ episodes }: { episodes: readonly EpisodeData[] }): React.ReactElement {
@@ -125,7 +138,7 @@ function RewardChart({ episodes }: { episodes: readonly EpisodeData[] }): React.
 
   return (
     <div className={styles.chartCard + ' ' + styles.wide}>
-      <h3 className={styles.chartTitle}>奖励曲线</h3>
+      <ChartTitle text="奖励曲线" tip="每轮累计奖励及 100 轮滑动平均，上升表示策略在改善" />
       <div ref={bindRef} className={styles.chart} />
     </div>
   );
@@ -178,7 +191,7 @@ function LossChart({ summaries }: { summaries: readonly SummaryData[] }): React.
 
   return (
     <div className={styles.chartCard}>
-      <h3 className={styles.chartTitle}>Loss 曲线</h3>
+      <ChartTitle text="Loss 曲线" tip="神经网络预测误差，下降表示模型学习到了更准确的价值估计" />
       <div ref={bindRef} className={styles.chart} />
     </div>
   );
@@ -230,7 +243,10 @@ function EpsilonChart({ episodes }: { episodes: readonly EpisodeData[] }): React
 
   return (
     <div className={styles.chartCard}>
-      <h3 className={styles.chartTitle}>Epsilon 衰减</h3>
+      <ChartTitle
+        text="Epsilon 衰减"
+        tip="随机探索概率，高 = 多探索，低 = 多利用已学策略；训练后期应接近 0"
+      />
       <div ref={bindRef} className={styles.chart} />
     </div>
   );
@@ -278,7 +294,10 @@ function ScoreChart({ episodes }: { episodes: readonly EpisodeData[] }): React.R
 
   return (
     <div className={styles.chartCard}>
-      <h3 className={styles.chartTitle}>分数分布</h3>
+      <ChartTitle
+        text="分数分布"
+        tip="每轮游戏内分数（吃到果实数），上升表示蛇存活越久、吃得越多"
+      />
       <div ref={bindRef} className={styles.chart} />
     </div>
   );
@@ -326,7 +345,7 @@ function LengthChart({ episodes }: { episodes: readonly EpisodeData[] }): React.
 
   return (
     <div className={styles.chartCard}>
-      <h3 className={styles.chartTitle}>Episode 长度</h3>
+      <ChartTitle text="Episode 长度" tip="每轮存活步数，越长表示蛇越能避免撞墙/撞自己" />
       <div ref={bindRef} className={styles.chart} />
     </div>
   );

--- a/src/training/TrainingApp.tsx
+++ b/src/training/TrainingApp.tsx
@@ -1,14 +1,13 @@
 /**
  * TrainingApp —— 训练可视化页面（MPA 独立入口）
  *
- * 左侧：缩小的 Device 外壳，AI Autopilot 操控 Snake
+ * 左侧：缩小的 Device 外壳
+ *   - 训练中：确定性回放训练子进程实际跑的最新一轮（seed + actions）
+ *   - 训练后：加载最终模型做实时推理
  * 右侧：ECharts Dashboard，轮询 JSONL 实时展示训练曲线
- *
- * TODO: 支持切换已训练模型，在游戏机上展示 AI 自动玩
- * TODO: 实时显示训练过程——固定速度取当前最新路径回放，无需逐步全量展示
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { InferenceAgent, ModelInfo } from '@/ai/inference';
 import { loadInferenceAgent } from '@/ai/inference';
@@ -34,112 +33,240 @@ const AI_TICK_MS = 100;
 
 const LOG_URL = '/api/training/train-log.jsonl';
 const MODEL_URL = '/api/training/model.json';
+const REPLAY_URL = '/api/training/latest-replay.json';
 
-type AgentStatus = 'loading' | 'ready' | 'no-model';
+interface ReplayData {
+  readonly ep: number;
+  readonly seed: number;
+  readonly actions: readonly number[];
+}
+
+type DisplayMode = 'waiting' | 'replay' | 'inference';
 
 export function TrainingApp(): React.ReactElement {
-  // AI 用的 headless context：与真机一致的 10x20 场地
   const [displayCtx] = useState(() =>
     createHeadlessContext({ seed: 1, width: FIELD_W, height: FIELD_H })
   );
   const displayEnv = useMemo<GameEnv>(() => toGameEnv(displayCtx), [displayCtx]);
 
-  const [rlEnvSeed] = useState(() => Date.now());
-  const rlEnv = useMemo(
-    () => createSnakeRLEnv({ width: FIELD_W, height: FIELD_H, seed: rlEnvSeed }),
-    [rlEnvSeed]
+  const rlEnv = useMemo(() => createSnakeRLEnv({ width: FIELD_W, height: FIELD_H }), []);
+
+  const [score, setScore] = useState(0);
+  const [hiScore, setHiScore] = useState(0);
+  const [displayMode, setDisplayMode] = useState<DisplayMode>('waiting');
+  const [replayEp, setReplayEp] = useState(0);
+  const [modelInfo, setModelInfo] = useState<ModelInfo | null>(null);
+
+  // ── 回放状态 ──
+  const replayRef = useRef<ReplayData | null>(null);
+  const prefetchedRef = useRef<ReplayData | null>(null);
+  const replayStepRef = useRef(0);
+  const rlStateRef = useRef<SnakeRLState | null>(null);
+  /** 死亡冷却：> 0 时每 tick 递减，到 0 自动切下一条。用 tick 计数代替 setTimeout，避免被 effect 清理取消 */
+  const cooldownRef = useRef(0);
+
+  // ── 推理状态 ──
+  const agentRef = useRef<InferenceAgent | null>(null);
+
+  // 训练数据轮询
+  const data = useTrainingData(LOG_URL);
+  const doneRef = useRef(false);
+  useEffect(() => {
+    doneRef.current = data.done;
+  }, [data.done]);
+
+  // 拉取最新回放数据
+  const fetchReplay = useCallback(async (): Promise<ReplayData | null> => {
+    try {
+      const res = await fetch(REPLAY_URL);
+      if (!res.ok) return null;
+      return (await res.json()) as ReplayData;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // 回放进行中持续预取最新数据，结束时无需等 fetch
+  useEffect(() => {
+    if (displayMode !== 'replay') return;
+    let cancelled = false;
+    const poll = async (): Promise<void> => {
+      const data = await fetchReplay();
+      if (!cancelled && data) prefetchedRef.current = data;
+    };
+    void poll();
+    const timer = setInterval(() => void poll(), 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [displayMode, fetchReplay]);
+
+  // 开始回放一轮录像
+  const startReplay = useCallback(
+    (replay: ReplayData) => {
+      replayRef.current = replay;
+      replayStepRef.current = 0;
+      rlStateRef.current = rlEnv.reset(replay.seed);
+      setScore(0);
+      setReplayEp(replay.ep);
+      setDisplayMode('replay');
+      cooldownRef.current = 0;
+
+      // 渲染初始帧
+      const state = rlStateRef.current;
+      if (state) {
+        displayEnv.screen.clear();
+        renderSnake(displayEnv, state.game);
+      }
+    },
+    [rlEnv, displayEnv]
   );
 
-  const [agentStatus, setAgentStatus] = useState<AgentStatus>('loading');
-  const [modelInfo, setModelInfo] = useState<ModelInfo | null>(null);
-  const agentRef = useRef<InferenceAgent | null>(null);
-  const rlStateRef = useRef<SnakeRLState | null>(null);
-  const [score, setScore] = useState(0);
+  // 切换到推理模式（用 ref 存最新引用，避免递归重试时引用声明前变量）
+  const switchToInferenceRef = useRef<(() => Promise<void>) | null>(null);
+  useEffect(() => {
+    const fn = async (): Promise<void> => {
+      try {
+        const agent = await loadInferenceAgent(MODEL_URL, OBS_SIZE);
+        agentRef.current?.dispose();
+        agentRef.current = agent;
+        setModelInfo(agent.info);
+        rlStateRef.current = rlEnv.reset(Date.now());
+        setScore(0);
+        setDisplayMode('inference');
+        cooldownRef.current = 0;
+      } catch {
+        setTimeout(() => void switchToInferenceRef.current?.(), 3000);
+      }
+    };
+    switchToInferenceRef.current = fn;
+  }, [rlEnv]);
 
-  // 加载推理模型（失败后每 3 秒重试，训练完成时自动加载）
+  // 训练完成时从回放切到推理
+  useEffect(() => {
+    if (data.done && displayMode !== 'inference') {
+      void switchToInferenceRef.current?.();
+    }
+  }, [data.done, displayMode]);
+
+  // 首次挂载：尝试拉取回放
   useEffect(() => {
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout>;
 
-    const tryLoad = async (): Promise<void> => {
-      try {
-        const agent = await loadInferenceAgent(MODEL_URL, OBS_SIZE);
-        if (cancelled) {
-          agent.dispose();
-          return;
-        }
-        agentRef.current?.dispose();
-        agentRef.current = agent;
-        setModelInfo(agent.info);
-        setAgentStatus('ready');
-      } catch {
-        if (!cancelled) {
-          setAgentStatus('no-model');
-          retryTimer = setTimeout(() => void tryLoad(), 3000);
-        }
+    const tryFetch = async (): Promise<void> => {
+      const replay = await fetchReplay();
+      if (cancelled) return;
+      if (replay) {
+        startReplay(replay);
+      } else {
+        retryTimer = setTimeout(() => void tryFetch(), 1000);
       }
     };
 
-    void tryLoad();
+    void tryFetch();
     return () => {
       cancelled = true;
       clearTimeout(retryTimer);
-      agentRef.current?.dispose();
-      agentRef.current = null;
     };
-  }, []);
+  }, [fetchReplay, startReplay]);
 
-  // 初始化第一局
-  useEffect(() => {
-    rlStateRef.current = rlEnv.reset(rlEnvSeed);
-  }, [rlEnv, rlEnvSeed]);
-
-  // AI 游戏循环——死亡后等 300ms 重开，期间跳过 step 防止重复 reset
-  const resettingRef = useRef(false);
-  const resetTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // 主循环：回放 / 推理共用同一个 setInterval
+  // 全部用 ref + tick 计数器驱动，不使用 setTimeout，
+  // 避免 useEffect 清理函数取消定时器导致卡死
+  const COOLDOWN_TICKS = 3; // 死亡后停顿 3 tick（300ms）
 
   useEffect(() => {
     const timer = setInterval(() => {
-      const agent = agentRef.current;
+      // 冷却中：倒计时，到 0 自动切下一条
+      if (cooldownRef.current > 0) {
+        cooldownRef.current--;
+        if (cooldownRef.current === 0) {
+          if (displayMode === 'replay') {
+            if (doneRef.current) return;
+            const replay = replayRef.current;
+            const next = prefetchedRef.current ?? replay;
+            prefetchedRef.current = null;
+            if (next) startReplay(next);
+          } else if (displayMode === 'inference') {
+            rlStateRef.current = rlEnv.reset(Date.now());
+            setScore(0);
+            displayEnv.screen.clear();
+            if (rlStateRef.current) renderSnake(displayEnv, rlStateRef.current.game);
+          }
+        }
+        return;
+      }
+
       const state = rlStateRef.current;
-      if (!agent || !state || resettingRef.current) return;
+      if (!state) return;
 
-      const obs = rlEnv.encodeState(state);
-      const actionIdx = agent.act(obs);
-      const result = rlEnv.step(state, rlEnv.actionSpace[actionIdx]!);
+      // ── 回放模式 ──
+      if (displayMode === 'replay') {
+        const replay = replayRef.current;
+        if (!replay) return;
 
-      rlStateRef.current = result.state;
-      setScore(result.state.score);
+        const step = replayStepRef.current;
+        if (step >= replay.actions.length) {
+          cooldownRef.current = COOLDOWN_TICKS;
+          return;
+        }
 
-      displayEnv.screen.clear();
+        const actionIdx = replay.actions[step]!;
+        const action = rlEnv.actionSpace[actionIdx]!;
+        const result = rlEnv.step(state, action);
+        rlStateRef.current = result.state;
+        replayStepRef.current = step + 1;
+        setScore(result.state.score);
+        setHiScore((prev) => Math.max(prev, result.state.score));
+        displayEnv.screen.clear();
 
-      if (result.done) {
-        resettingRef.current = true;
-        resetTimerRef.current = setTimeout(() => {
-          rlStateRef.current = rlEnv.reset(Date.now());
-          setScore(0);
-          resettingRef.current = false;
-        }, 300);
-      } else {
-        renderSnake(displayEnv, result.state.game);
+        if (!result.done) {
+          renderSnake(displayEnv, result.state.game);
+        }
+        return;
+      }
+
+      // ── 推理模式 ──
+      if (displayMode === 'inference') {
+        const agent = agentRef.current;
+        if (!agent) return;
+
+        const obs = rlEnv.encodeState(state);
+        const actionIdx = agent.act(obs);
+        const result = rlEnv.step(state, rlEnv.actionSpace[actionIdx]!);
+        rlStateRef.current = result.state;
+        setScore(result.state.score);
+        setHiScore((prev) => Math.max(prev, result.state.score));
+        displayEnv.screen.clear();
+
+        if (result.done) {
+          cooldownRef.current = COOLDOWN_TICKS;
+        } else {
+          renderSnake(displayEnv, result.state.game);
+        }
       }
     }, AI_TICK_MS);
-    return () => {
-      clearInterval(timer);
-      clearTimeout(resetTimerRef.current);
-    };
-  }, [rlEnv, displayEnv]);
 
-  // 训练数据轮询
-  const data = useTrainingData(LOG_URL);
+    return () => clearInterval(timer);
+  }, [displayMode, rlEnv, displayEnv, startReplay]);
 
-  const trainedEp = data.config?.totalEpisodes ?? 0;
+  // 组件卸载清理
+  useEffect(
+    () => () => {
+      agentRef.current?.dispose();
+    },
+    []
+  );
+
+  const totalEp = data.config?.totalEpisodes ?? 0;
   const statusText =
-    agentStatus === 'ready' && modelInfo
-      ? `AI 就绪 · ${trainedEp} 轮训练 · ${modelInfo.layers} 层 ${(modelInfo.params / 1000).toFixed(1)}K 参数`
-      : agentStatus === 'loading'
-        ? '加载模型中…'
-        : '等待训练完成…';
+    displayMode === 'inference' && modelInfo
+      ? `训练完成 · 模型推理 · ${modelInfo.layers} 层 ${(modelInfo.params / 1000).toFixed(1)}K 参数`
+      : displayMode === 'replay'
+        ? `训练中 · 回放第 ${replayEp} 轮${totalEp ? ` / ${totalEp}` : ''}`
+        : '等待首轮训练…';
 
   return (
     <div className={styles.page}>
@@ -151,10 +278,12 @@ export function TrainingApp(): React.ReactElement {
               <SidePanel
                 power
                 score={score}
+                hiScore={hiScore}
                 speed={1}
                 level={1}
                 soundOn={false}
                 pauseMode={false}
+                aiMode={displayMode !== 'waiting'}
               />
             }
             buttons={<Buttons labels={defaultButtonLabels()} onInput={() => undefined} />}

--- a/src/training/TrainingApp.tsx
+++ b/src/training/TrainingApp.tsx
@@ -153,7 +153,7 @@ export function TrainingApp(): React.ReactElement {
   // 首次挂载：尝试拉取回放
   useEffect(() => {
     let cancelled = false;
-    let retryTimer: ReturnType<typeof setTimeout>;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
 
     const tryFetch = async (): Promise<void> => {
       const replay = await fetchReplay();
@@ -168,7 +168,7 @@ export function TrainingApp(): React.ReactElement {
     void tryFetch();
     return () => {
       cancelled = true;
-      clearTimeout(retryTimer);
+      if (retryTimer !== undefined) clearTimeout(retryTimer);
     };
   }, [fetchReplay, startReplay]);
 

--- a/src/training/useTrainingData.ts
+++ b/src/training/useTrainingData.ts
@@ -32,6 +32,8 @@ export interface TrainingData {
   readonly config: TrainingConfig | null;
   readonly episodes: readonly EpisodeData[];
   readonly summaries: readonly SummaryData[];
+  /** 训练是否已完成（JSONL 中出现 { done: true }） */
+  readonly done: boolean;
 }
 
 const POLL_MS = 500;
@@ -40,6 +42,7 @@ export function useTrainingData(url: string): TrainingData {
   const [config, setConfig] = useState<TrainingConfig | null>(null);
   const [episodes, setEpisodes] = useState<readonly EpisodeData[]>([]);
   const [summaries, setSummaries] = useState<readonly SummaryData[]>([]);
+  const [done, setDone] = useState(false);
   const lastLineCount = useRef(0);
   const pollingRef = useRef(false);
 
@@ -64,7 +67,9 @@ export function useTrainingData(url: string): TrainingData {
       for (const line of newLines) {
         try {
           const data = JSON.parse(line) as Record<string, unknown>;
-          if ('totalEpisodes' in data) {
+          if ('done' in data && data.done === true) {
+            setDone(true);
+          } else if ('totalEpisodes' in data) {
             setConfig(data as unknown as TrainingConfig);
           } else if ('avgReward' in data) {
             newSummaries.push(data as unknown as SummaryData);
@@ -98,5 +103,5 @@ export function useTrainingData(url: string): TrainingData {
     };
   }, [poll]);
 
-  return { config, episodes, summaries };
+  return { config, episodes, summaries, done };
 }

--- a/src/ui/Buttons/Buttons.module.css
+++ b/src/ui/Buttons/Buttons.module.css
@@ -47,6 +47,10 @@
     box-shadow 80ms ease-out;
 }
 
+.smallButton:focus {
+  outline: none;
+}
+
 .smallButton:active {
   background-color: rgb(143, 10, 47);
   transform: translateY(1px);
@@ -105,6 +109,10 @@
   transition:
     background-color 80ms ease-out,
     box-shadow 80ms ease-out;
+}
+
+.button:focus {
+  outline: none;
 }
 
 .button:active {
@@ -214,6 +222,10 @@
   transition:
     background-color 80ms ease-out,
     box-shadow 80ms ease-out;
+}
+
+.rotateButton:focus {
+  outline: none;
 }
 
 /* :active 必须保留 rotateZ(60deg)，否则按下瞬间按钮会回正 */

--- a/src/ui/Buttons/Buttons.tsx
+++ b/src/ui/Buttons/Buttons.tsx
@@ -88,6 +88,7 @@ export function Buttons({
       tabIndex: -1 as const,
       onPointerDown: (e: ReactPointerEvent<HTMLButtonElement>): void => {
         e.currentTarget.setPointerCapture(e.pointerId);
+        e.currentTarget.blur();
         onInputRef.current?.(btn, 'press');
         if (REPEAT_KEYS.has(btn) && !repeatTimersRef.current.has(btn)) {
           const timers = repeatTimersRef.current;

--- a/src/ui/Buttons/Buttons.tsx
+++ b/src/ui/Buttons/Buttons.tsx
@@ -85,6 +85,7 @@ export function Buttons({
 
   const makeHandlers = useCallback(
     (btn: Button) => ({
+      tabIndex: -1 as const,
       onPointerDown: (e: ReactPointerEvent<HTMLButtonElement>): void => {
         e.currentTarget.setPointerCapture(e.pointerId);
         onInputRef.current?.(btn, 'press');

--- a/src/ui/SidePanel/SidePanel.tsx
+++ b/src/ui/SidePanel/SidePanel.tsx
@@ -1,4 +1,6 @@
-import type { Pixel } from '@/sdk';
+import { useEffect, useReducer } from 'react';
+
+import type { Screen } from '@/engine/types';
 
 import styles from './SidePanel.module.css';
 
@@ -11,33 +13,40 @@ export interface SidePanelProps {
   power?: boolean;
   score?: number;
   hiScore?: number;
-  /**
-   * 下一块方块的预览像素（相对坐标）；null / undefined 表示不显示。
-   * Tetris playing 时由 App 从 TetrisState.next 提取传入
-   */
-  nextPreview?: ReadonlyArray<Pixel> | null;
+  /** 4×2 预览屏 framebuffer；游戏在 render 里画，此组件订阅渲染 */
+  nextScreen?: Screen | null;
   level?: number;
   speed?: number;
   /** 'pause' 指示灯是否点亮 */
   pauseMode?: boolean;
   /** 'sound' 指示灯是否点亮（反映 ctx.soundOn） */
   soundOn?: boolean;
+  /** 'AI' 指示灯是否点亮 */
+  aiMode?: boolean;
 }
 
 /**
- * 固定 4×2 的迷你像素网格，与主屏同风格（外框 + 内方块）但缩小到 ~80%。
- * 始终占位，有数据时亮格子、没数据时全暗阴影
+ * 固定 4×2 的迷你像素网格，与主屏同风格（外框 + 内方块）。
+ * 订阅 Screen buffer 变化触发 re-render，用 DOM span 模拟像素
  */
 function NextPreview({
-  pixels,
+  screen,
 }: {
-  readonly pixels: ReadonlyArray<Pixel> | null | undefined;
+  readonly screen: Screen | null | undefined;
 }): React.ReactElement {
-  const set = new Set(pixels?.map(([x, y]) => `${x},${y}`) ?? []);
+  const [, forceUpdate] = useReducer((c: number) => c + 1, 0);
+
+  useEffect(() => {
+    if (!screen) return;
+    return screen.subscribe(forceUpdate);
+  }, [screen]);
+
+  const cols = screen?.width ?? 4;
+  const rows = screen?.height ?? 2;
   const cells: React.ReactElement[] = [];
-  for (let y = 0; y < 2; y++) {
-    for (let x = 0; x < 4; x++) {
-      const lit = set.has(`${x},${y}`);
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      const lit = screen ? screen.getPixel(x, y) : false;
       cells.push(
         <span key={`${x},${y}`} className={lit ? styles.pixelOn : styles.pixelOff}>
           <span className={styles.pixelInner} />
@@ -59,11 +68,12 @@ export function SidePanel({
   power = true,
   score = 0,
   hiScore = 0,
-  nextPreview,
+  nextScreen,
   level = 1,
   speed = 1,
   pauseMode = false,
   soundOn = false,
+  aiMode = false,
 }: SidePanelProps): React.ReactElement {
   const className = power ? styles.panel : `${styles.panel} ${styles.poweredOff}`;
   return (
@@ -78,7 +88,7 @@ export function SidePanel({
       </div>
       <div className={styles.group}>
         <p className={styles.label}>NEXT</p>
-        <NextPreview pixels={nextPreview} />
+        <NextPreview screen={nextScreen} />
       </div>
       <div className={styles.group}>
         <p className={styles.label}>LEVEL</p>
@@ -90,6 +100,7 @@ export function SidePanel({
       </div>
 
       <div className={styles.indicators}>
+        <p className={aiMode ? styles.indicatorOn : styles.indicatorOff}>AI</p>
         <p className={pauseMode ? styles.indicatorOn : styles.indicatorOff}>PAUSE</p>
         <p className={soundOn ? styles.indicatorOn : styles.indicatorOff}>SOUND</p>
       </div>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "master": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **nextScreen 数据流重构**：游戏 `render` 直接写 `nextScreen` buffer，SidePanel 订阅渲染，消除 `Game` 接口上的 `getNextPreview` 方法；SidePanel 预览改为 DOM 像素风格
- **AI 自动玩**：App 新增 AI 模式（选关界面按掌机 B 键 / 键盘 X 触发），动态加载模型 + 注入推理动作到游戏循环；SidePanel 显示 AI 指示灯；game over 后自动重开
- **训练回放改进**：确定性重放最新一轮动作序列 + 预取消除切换白屏；死亡冷却改用 tick 计数器替代 setTimeout 避免 useEffect cleanup 卡死；训练完成后自动切换到模型推理模式
- **Dashboard 改进**：图表标题增加问号 tooltip 说明含义；训练场景支持页面级最高分（刷新复位）
- **按钮交互**：屏幕按钮加 `tabIndex={-1}` + `outline: none`，避免点击后键盘按键再触发焦点边框；键盘映射 fallback 到 `toLowerCase()`，大写锁定 / Shift 也能正常触发
- **其他**：新增 `vercel.json` 阻止 Vercel 部署 master 分支；`dqn.ts` / `sdk/types.ts` 补充 TODO 注释

## Test plan

- [x] `pnpm dev` 启动后，选关界面按 **X** 键，验证 AI 自动玩 Snake 正常工作（加载模型 → AI 指示灯亮 → 蛇自动移动 → game over 自动重开）
- [x] 验证 Tetris 的 NEXT 预览在 SidePanel 中正常显示（DOM 像素风格）
- [x] `pnpm train` 启动训练后,验证游戏机回放最新一轮训练数据、Dashboard 图表 tooltip 显示、最高分跟踪
- [x] 训练完成后验证自动切换到推理模式
- [x] 验证点击屏幕按钮后再按键盘，按钮周围不出现焦点边框
- [x] 验证大写锁定开启或 Shift 状态下键盘映射正常工作